### PR TITLE
add the delete request on the API to remove a character

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,17 +233,17 @@ GEM
       net-protocol
     net-ssh (7.3.2)
     nio4r (2.7.5)
-    nokogiri (1.19.2-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-aarch64-linux-musl)
+    nokogiri (1.19.3-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-gnu)
+    nokogiri (1.19.3-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-musl)
+    nokogiri (1.19.3-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-musl)
+    nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
@@ -270,7 +270,7 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
@@ -540,12 +540,12 @@ CHECKSUMS
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   net-ssh (7.3.2) sha256=65029e213c380e20e5fd92ece663934ab0a0fe888e0cd7cc6a5b664074362dd4
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.2-aarch64-linux-gnu) sha256=c34d5c8208025587554608e98fd88ab125b29c80f9352b821964e9a5d5cfbd19
-  nokogiri (1.19.2-aarch64-linux-musl) sha256=7f6b4b0202d507326841a4f790294bf75098aef50c7173443812e3ac5cb06515
-  nokogiri (1.19.2-arm-linux-gnu) sha256=b7fa1139016f3dc850bda1260988f0d749934a939d04ef2da13bec060d7d5081
-  nokogiri (1.19.2-arm-linux-musl) sha256=61114d44f6742ff72194a1b3020967201e2eb982814778d130f6471c11f9828c
-  nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
-  nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
+  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
+  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
+  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
+  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
+  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
+  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
@@ -564,7 +564,7 @@ CHECKSUMS
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
-  rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3

--- a/app/controllers/api/v1/characters_controller.rb
+++ b/app/controllers/api/v1/characters_controller.rb
@@ -36,4 +36,24 @@ class Api::V1::CharactersController < ApiController
           render json: character.errors, status: :unprocessable_entity
         end
       end
+
+      api :DELETE, "/characters/:id", "delete a character"
+      api_version "v1"
+      returns code: 200
+      error :not_found, "character not found"
+      error :unprocessable_entity, "legendary character shouldn't be deleted"
+
+      def destroy
+        begin
+          character = Character.find(params[:id])
+        rescue ActiveRecord::RecordNotFound
+          render json: { message: "Character not found" }, status: :not_found
+        else
+          if character.destroy && character.destroyed?
+            render json: { message: "Character deleted" }, status: :ok
+          else
+            render json: { message: "Character can not be deleted, #{character.errors[:base].to_a.join(' ')}" }, status: :unprocessable_entity
+          end
+        end
+      end
 end

--- a/app/controllers/api/v1/characters_controller.rb
+++ b/app/controllers/api/v1/characters_controller.rb
@@ -44,16 +44,13 @@ class Api::V1::CharactersController < ApiController
       error :unprocessable_entity, "legendary character shouldn't be deleted"
 
       def destroy
-        begin
-          character = Character.find(params[:id])
-        rescue ActiveRecord::RecordNotFound
-          render json: { message: "Character not found" }, status: :not_found
+        character = Character.find(params[:id])
+        if character.destroy
+          render json: { message: "Character deleted" }, status: :ok
         else
-          if character.destroy && character.destroyed?
-            render json: { message: "Character deleted" }, status: :ok
-          else
-            render json: { message: "Character can not be deleted, #{character.errors[:base].to_a.join(' ')}" }, status: :unprocessable_entity
-          end
+          render json: { message: "Character can not be deleted, #{character.errors[:base].to_a.join(' ')}" }, status: :unprocessable_entity
         end
+      rescue ActiveRecord::RecordNotFound
+        render json: { message: "Character not found" }, status: :not_found
       end
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -5,6 +5,7 @@ class Character < ApplicationRecord
             inclusion: { in: 1..5, message: I18n.t("Characters.errors.number_between_1_5")   }
   validates :region, presence: { message: I18n.t("Characters.errors.choose_region") }
   enum :region, %w[ Liyue Fontaine Montstadt ].index_by(&:itself)
+  before_destroy :check_legendary_character
 
   def self.ransackable_associations(_auth_object = nil)
     %w[rarity region]
@@ -12,5 +13,12 @@ class Character < ApplicationRecord
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[rarity region]
+  end
+
+  def check_legendary_character
+    if rarity == 5
+      errors.add(:base, "Shouldn't delete legendary characters")
+      throw :abort
+    end
   end
 end

--- a/test/controllers/admin/characters_controller_test.rb
+++ b/test/controllers/admin/characters_controller_test.rb
@@ -5,7 +5,9 @@ class Admin::CharactersControllerTest < ActionDispatch::IntegrationTest
 
   test "Should get index and show information of all characters when the user is logged in " do
     sign_in users(:admin_users)
+
     get admin_characters_url
+
     assert_response :success
     character = characters(:charlotte_from_fontaine_region)
     assert_includes response.body, character.name
@@ -14,13 +16,16 @@ class Admin::CharactersControllerTest < ActionDispatch::IntegrationTest
 
   test "shouldn't get index and show information when the user isn't logged in" do
     sign_out :user
+
     get admin_characters_url
+
     assert_response :redirect
     assert_redirected_to new_user_session_path
   end
 
   test "we should be able to create a new user" do
     sign_in users(:admin_users)
+
     assert_difference -> { Character.count } => +1 do
       post admin_characters_path, params: {
         character: {
@@ -48,6 +53,7 @@ class Admin::CharactersControllerTest < ActionDispatch::IntegrationTest
           description: "un personnage 3 étoiles" }
       }
     end
+
     assert_response :redirect
     assert_not_includes Character.last&.name.to_s, "Yelan"
   end

--- a/test/controllers/api/v1/characters_controller_test.rb
+++ b/test/controllers/api/v1/characters_controller_test.rb
@@ -78,4 +78,37 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal response.parsed_body, error_message.as_json
   end
+
+  test "Should be able to delete a character" do
+    character = characters(:yanfei_from_fontaine_region)
+
+    delete api_v1_character_url(id: character.id)
+
+    assert_response :ok
+
+    message = { message: "Character deleted" }
+    assert_equal response.parsed_body, message.as_json
+  end
+
+  test "Shouldn't be able to delete a character that doesn't exist" do
+    delete api_v1_character_url(id: 0)
+
+    assert_response :not_found
+
+    message = { message: "Character not found" }
+
+    assert_equal response.parsed_body, message.as_json
+  end
+
+  test "Should render a message when the character is a 5 star and was not destroy from the database" do
+    character = characters(:eula_from_mondsatdt)
+
+    delete api_v1_character_url(id: character.id)
+
+    assert_response :unprocessable_entity
+
+    error_message = "Shouldn't delete legendary characters"
+
+    assert_includes response.parsed_body[:message], error_message.as_json
+  end
 end

--- a/test/fixtures/characters.yml
+++ b/test/fixtures/characters.yml
@@ -19,3 +19,9 @@ yanfei_from_fontaine_region :
   description: Yanfei est un personnage Pyro 4 étoiles de Genshin Impact qui utilise un catalyseur
   rarity: 4
   region: Liyue
+
+eula_from_mondsatdt:
+  name: Eula
+  description: Eula Lawrence est un personnage Cryo jouable dans Genshin Impact. Descendante du tristement célèbre et tyrannique Clan Lawrence, Eula est la Capitaine de l'unité de reconnaissance de l'Ordre de Favonius.
+  rarity: 5
+  region: Montstadt


### PR DESCRIPTION
**Description:**

- On ajouté la fonction `destroy` pour pouvoir supprimer un personnage  avec la requête DELETE sur l'API
  -  on peut supprimer que les personnages qui ont entre 1 et 4 étoiles 
