### PR TITLE
view a playable character on the api

### DIFF
--- a/app/controllers/api/v1/playable_characters_controller.rb
+++ b/app/controllers/api/v1/playable_characters_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::PlayableCharactersController < ApiController
         render json: { playable_character: characters_json }
       end
 
-      api :GET, "/api/v1/playable_characters/:id", "list of a playable characters"
+      api :GET, "/api/v1/playable_characters/:id", "render a playable characters"
       api_version "v1"
       returns code: 200
       error :not_found, I18n.t("Playable_Characters.errors.record_not_found")

--- a/app/controllers/api/v1/playable_characters_controller.rb
+++ b/app/controllers/api/v1/playable_characters_controller.rb
@@ -3,11 +3,30 @@ class Api::V1::PlayableCharactersController < ApiController
         formats [ "json" ]
       end
 
+      before_action :find_playable_character, only: [ :show ]
+
       api :GET, "/api/v1/playable_characters", "list of all playable characters"
       api_version "v1"
       returns code: 200
+
       def index
         characters_json = PlayableCharacter.all.map { |playable_character| PlayableCharacterJson.new(playable_character:).to_h }
         render json: { playable_character: characters_json }
+      end
+
+      api :GET, "/api/v1/playable_characters/:id", "list of a playable characters"
+      api_version "v1"
+      returns code: 200
+      error :not_found, I18n.t("Playable_Characters.errors.record_not_found")
+
+      def show
+        render json: PlayableCharacterJson.new(playable_character: @playable_character).to_h
+      end
+
+
+      def find_playable_character
+        @playable_character = PlayableCharacter.find(params[:id])
+      rescue ActiveRecord::RecordNotFound => e
+        render status: :not_found, json: { error:  I18n.t("Playable_Characters.errors.record_not_found"), details: { field: [ e ] } }
       end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,3 +49,5 @@ en:
       update:
         success: "Character successfully updated!"
         record_invalid: "Character can't be updated"
+      errors:
+        record_not_found: "This playable character wasn't found"

--- a/test/controllers/api/v1/playable_characters_controller_test.rb
+++ b/test/controllers/api/v1/playable_characters_controller_test.rb
@@ -15,4 +15,24 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
     assert_includes response.parsed_body["playable_character"], playable_characters_to_json.as_json
     assert_equal PlayableCharacter.count,  response.parsed_body["playable_character"].count
   end
+  test "Should view a playable character if we find their ID" do
+    playable_character = playable_characters(:charlotte_from_fontaine_region)
+    get api_v1_playable_character_url(id: playable_character.id)
+
+    assert_response :success
+
+    playable_character_to_json = PlayableCharacterJson.new(playable_character:).to_h
+
+    assert_equal response.parsed_body, playable_character_to_json.as_json
+  end
+
+  test "Shouldn't be able to see a playable character if we can't find their ID and should return an error" do
+    get api_v1_playable_character_url(id: 0)
+
+    assert_response :not_found
+
+    error_message = I18n.t("Playable_Characters.errors.record_not_found")
+
+    assert_includes response.parsed_body[:error], error_message.as_json
+  end
 end


### PR DESCRIPTION
**Description:** 

- permet de voir tous les détails d'un personnage jouable ( playable_character) à l'endpoint GET 'http://localhost:3000/api/v1/playable_characters/:id'

Dans le cas où on trouve l'ID du personnage jouable : 

<img width="1919" height="829" alt="image" src="https://github.com/user-attachments/assets/4f33a356-be52-485a-8581-bfa5bbad7f78" />

Dans le cas où on trouve pas l'ID du personnage jouable  : 

<img width="1919" height="833" alt="image" src="https://github.com/user-attachments/assets/c08a3d0b-8a4e-4600-9a55-19d650d56013" />
