### PR TITLE
feat: add the delete action to be able to delete a playable character…

### DIFF
--- a/app/controllers/api/v1/playable_characters_controller.rb
+++ b/app/controllers/api/v1/playable_characters_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::PlayableCharactersController < ApiController
         formats [ "json" ]
       end
 
-      before_action :find_playable_character, only: [ :show ]
+      before_action :find_playable_character, only: [ :show, :destroy ]
 
       api :GET, "/api/v1/playable_characters", "list of all playable characters"
       api_version "v1"
@@ -36,6 +36,22 @@ class Api::V1::PlayableCharactersController < ApiController
         render json: PlayableCharacterJson.new(playable_character: @playable_character).to_h, status: :created
       rescue ActiveRecord::RecordInvalid => e
         render status: :unprocessable_entity, json: { error: I18n.t("Playable_Characters.create.record_invalid"), details: { field: [ e.message ] } }
+      end
+
+
+      api :DELETE, "/playable_characters/:id", "delete a playable character"
+      api_version "v1"
+      returns code: 200
+      error :unprocessable_content, "can't destroy a playable character who's a legendary one"
+      error :not_found, I18n.t("Playable_Characters.errors.record_not_found")
+
+      def destroy
+        ActiveRecord::Base.transaction do
+          @playable_character.character.destroy!
+        end
+        render json: { message: I18n.t("Playable_Characters.destroy.notice") }, status: :ok
+      rescue ActiveRecord::RecordNotDestroyed => e
+        render status: :unprocessable_entity, json: { error: I18n.t("Playable_Characters.errors.record_not_destroyed"), details: { field: [ @playable_character.character.errors[:base].to_a.join(" "), e.message ] } }
       end
 
       def find_playable_character

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,3 +51,4 @@ en:
         record_invalid: "Character can't be updated"
       errors:
         record_not_found: "This playable character wasn't found"
+        record_not_destroyed: "This playable character wasn't deleted"

--- a/test/controllers/api/v1/playable_characters_controller_test.rb
+++ b/test/controllers/api/v1/playable_characters_controller_test.rb
@@ -126,4 +126,39 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
     assert_not_equal  PlayableCharacter.last&.rarity.to_f, 3
     assert_not_equal  PlayableCharacter.last&.base_hp.to_f, 50
   end
+
+  test "Should delete a playablec character with a existing ID " do
+    playable_character = playable_characters(:yanfei_from_fontaine_region)
+
+    assert_difference [ -> { PlayableCharacter.count }, -> { Character.count } ], -1 do
+      delete api_v1_playable_character_url(id: playable_character.id)
+    end
+
+    assert_response :ok
+
+    assert_equal response.parsed_body[:message], I18n.t("Playable_Characters.destroy.notice")
+  end
+
+  test "Shouldn't be able to delete a playable character who doesn't exist in the database" do
+    assert_difference [ -> { PlayableCharacter.count }, -> { Character.count } ], 0 do
+      delete api_v1_playable_character_url(id: 0)
+    end
+
+   assert_response :not_found
+
+    assert_equal response.parsed_body[:error], I18n.t("Playable_Characters.errors.record_not_found").as_json
+  end
+
+
+  test "Shouldn't delete a playable character who is a legendary one" do
+    playable_characters = playable_characters(:eula_from_mondsatdt)
+
+    assert_difference [ -> { PlayableCharacter.count }, -> { Character.count } ], 0 do
+      delete api_v1_playable_character_url(id: playable_characters.id)
+    end
+
+    assert_response :unprocessable_entity
+
+    assert_includes response.parsed_body[:details][:field], I18n.t("Characters.destroy.should_not_delete_legendary_character").as_json
+  end
 end


### PR DESCRIPTION
**Description**

- Permet de supprimer un personnage jouable ( playable_character) de l'API :

Dans le cas où on a une personne qui existe  ;

<img width="972" height="431" alt="image" src="https://github.com/user-attachments/assets/559665cd-dd6d-4bfc-a800-18a7ef12c716" />

Dans le cas où le personnage n'existe pas dans la base de données : 

<img width="979" height="424" alt="image" src="https://github.com/user-attachments/assets/01416e3e-c025-4f0e-9a49-23c122c297e1" />


Dans le cas où le personnage est un personnage légendaire (ne devrait pas le supprimer parce que c'est un personnage 5 étoiles) :

<img width="979" height="431" alt="image" src="https://github.com/user-attachments/assets/ae9afd41-2a7d-44a5-b062-afc6a92bde4f" />
