### PR TITLE
add pagination on the character api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,9 @@ gem "sass-rails"
 # will generate the documentation for the API
 gem "apipie-rails", "~> 1.5"
 
+# will be used for the pagination
+gem "kaminari"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,6 +447,7 @@ DEPENDENCIES
   draper
   image_processing (~> 1.2)
   kamal
+  kaminari
   lefthook
   pg (~> 1.1)
   puma (>= 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activeadmin (3.5.2)
+    activeadmin (3.5.1)
       arbre (~> 1.2, >= 1.2.1)
       csv
       formtastic (>= 3.1)
@@ -133,7 +133,7 @@ GEM
       ruby2_keywords
     drb (2.2.3)
     ed25519 (1.4.0)
-    erb (6.0.5)
+    erb (6.0.4)
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
@@ -174,7 +174,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.21.1)
+    json (2.20.0)
     kamal (2.12.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -202,7 +202,7 @@ GEM
     lefthook (2.1.10)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.2)
+    loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.1)
@@ -293,8 +293,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.1)
-      loofah (~> 2.25, >= 2.25.2)
+    rails-html-sanitizer (1.7.0)
+      loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.3)
       actionpack (= 8.1.3)
@@ -404,9 +404,9 @@ GEM
       net-ssh (>= 2.8.0)
       ostruct
     thor (1.5.0)
-    thruster (0.1.23)
-    thruster (0.1.23-aarch64-linux)
-    thruster (0.1.23-x86_64-linux)
+    thruster (0.1.22)
+    thruster (0.1.22-aarch64-linux)
+    thruster (0.1.22-x86_64-linux)
     tilt (2.8.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -469,7 +469,7 @@ CHECKSUMS
   actionpack (8.1.3) sha256=af998cae4d47c5d581a2cc363b5c77eb718b7c4b45748d81b1887b25621c29a3
   actiontext (8.1.3) sha256=d291019c00e1ea9e6463011fa214f6081a56d7b9a1d224e7d3f6384c1dafc7d2
   actionview (8.1.3) sha256=1347c88c7f3edb38100c5ce0e9fb5e62d7755f3edc1b61cce2eb0b2c6ea2fd5d
-  activeadmin (3.5.2) sha256=fa58357079e21a173733bacc378322e29933a5d683e21993ac730205063e003e
+  activeadmin (3.5.1) sha256=1b17548f505ab7defe3e267b8129f51e0cdf5056ea4ccd3e4936563736902805
   activejob (8.1.3) sha256=a149b1766aa8204c3c3da7309e4becd40fcd5529c348cffbf6c9b16b565fe8d3
   activemodel (8.1.3) sha256=90c05cbe4cef3649b8f79f13016191ea94c4525ce4a5c0fb7ef909c4b91c8219
   activemodel-serializers-xml (1.0.3) sha256=fa1b16305e7254cc58a59c68833e3c0a593a59c8ab95d3be5aaea7cd9416c397
@@ -499,7 +499,7 @@ CHECKSUMS
   draper (4.0.6) sha256=e96990bffd4d98806913972f5ae2e6a7e8a5fb5433f17b80fbed7ba99d3c9236
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
-  erb (6.0.5) sha256=858e63488cb796c9daba8b6e9ff4b3879c395022049be9a66a8e00980e612eac
+  erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
@@ -519,7 +519,7 @@ CHECKSUMS
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jquery-rails (4.6.1) sha256=619f3496cdcdeaae1fd6dafa52dbac3fc45b745d4e09712da4184a16b3a8d9c0
-  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   kamal (2.12.0) sha256=c51d1ab085e515470f98d0c0f043637122b5ebf76e8b610cb1fbbed0b7f9b8fa
   kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
   kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909
@@ -529,7 +529,7 @@ CHECKSUMS
   lefthook (2.1.10) sha256=cc9c06bd8ea689e8b8016eab9769e54d696d07951860c1c6d28e8f6812e61b65
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
+  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
@@ -572,7 +572,7 @@ CHECKSUMS
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
-  rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
+  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
@@ -602,9 +602,9 @@ CHECKSUMS
   sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e
   sshkit (1.25.0) sha256=c8c6543cdb60f91f1d277306d585dd11b6a064cb44eab0972827e4311ff96744
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
-  thruster (0.1.23) sha256=ad3081e8ff3b5cb413768292c367f1e015c423bb6b35919b9b9f533af50d639f
-  thruster (0.1.23-aarch64-linux) sha256=042a05581dd1d750d1583d83817460b1f7fde254ed0b2bcd7ec56f9bed278c7a
-  thruster (0.1.23-x86_64-linux) sha256=9cd7265bf54e954575c8442e42d050ed8eb55df4f9d7da8fd6f94fcc0339baa5
+  thruster (0.1.22) sha256=f34fb82bd3e31570ae8f8b930e484f9e1db7b080cbc993d49090b161879c3e05
+  thruster (0.1.22-aarch64-linux) sha256=6c306241e8ff8912fb26705a15cbb7b44a4dfcedd59fa890b2c72811f15cfa0e
+  thruster (0.1.22-x86_64-linux) sha256=b96436be7f0854db632f421b4a53b795429a0bc95c15c2e1c1a7a6fdd1ed090f
   tilt (2.8.0) sha256=ba472eb2716fe1e04112d6d219a9dae938ec09a6a1e2ad3ecc7922e79bde3721
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f

--- a/app/controllers/api/v1/characters_controller.rb
+++ b/app/controllers/api/v1/characters_controller.rb
@@ -10,12 +10,15 @@ class Api::V1::CharactersController < ApiController
       param :region, [ "Liyue", "Fontaine", "Montstadt" ], desc: "Filter to show all characters from a region"
       param :rarity, :number, between: [ 1...5 ], desc: "Filter to show all characters of a rarity"
       param :characterable_type, [ "PlayableCharacter" ], desc: "Filter to get all character by type of character"
+      param :page, :number, greater_than: 0, desc: "Define the page where the elements are located"
+      param :per_page, :number, greater_than: 0, desc: "Set the number of items per page"
 
       def index
         conditions = permitted_params_to_filter.slice(:region, :rarity, :characterable_type).to_h.compact
         characters = Character.where(conditions)
-        characters_per_page = characters.page(params[:page]).per(params[:per_page])
+        characters_per_page = characters.page(permitted_params_to_filter[:page]).per(permitted_params_to_filter[:per_page])
         characters_json = characters_per_page.map { |character| CharacterJson.new(character:).to_h }
+
         render json: {
           characters: characters_json,
           pagination: {
@@ -91,6 +94,6 @@ class Api::V1::CharactersController < ApiController
         render status: :not_found, json: { message: "Character not found" }
       end
       def permitted_params_to_filter
-        params.permit(:region, :rarity, :characterable_type)
+        params.permit(:region, :rarity, :characterable_type, :page, :per_page)
       end
 end

--- a/app/controllers/api/v1/characters_controller.rb
+++ b/app/controllers/api/v1/characters_controller.rb
@@ -14,9 +14,17 @@ class Api::V1::CharactersController < ApiController
       def index
         conditions = permitted_params_to_filter.slice(:region, :rarity, :characterable_type).to_h.compact
         characters = Character.where(conditions)
-        characters_json = characters.map { |character| CharacterJson.new(character:).to_h }
-        render json: { characters: characters_json }, status: :ok
-   end
+        characters_per_page = characters.page(params[:page]).per(params[:per_page])
+        characters_json = characters_per_page.map { |character| CharacterJson.new(character:).to_h }
+        render json: {
+          characters: characters_json,
+          pagination: {
+            next_page: characters_per_page.next_page,
+            last_page: characters_per_page.total_pages,
+            current_page: characters_per_page.current_page
+          }
+        }, status: :ok
+      end
 
       api :GET, "/characters/:id", "render a character"
       api_version "v1"

--- a/app/controllers/api/v1/characters_controller.rb
+++ b/app/controllers/api/v1/characters_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::CharactersController < ApiController
           characters: characters_json,
           pagination: {
             next_page: characters_per_page.next_page,
-            last_page: characters_per_page.total_pages,
+            total_page: characters_per_page.total_pages,
             current_page: characters_per_page.current_page
           }
         }, status: :ok

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -5,10 +5,14 @@ class ApiController < ActionController::Base
   protect_from_forgery unless: -> { request.format.json? }
   # rescue all types of errors that may occur with the parameters defined in the API documentation
   rescue_from Apipie::ParamError, with: :render_invalid_param
-
+  # rescue any errors that might occur when the number of items per page is set to zero
+  rescue_from Kaminari::ZeroPerPageOperation, with: :render_pagination_error
   private
 
   def render_invalid_param(error)
     render json: { error: error.message }, status: :unprocessable_content
+  end
+  def render_pagination_error(error)
+    render json: { error: I18n.t("Api.error.pagination.value_per_page_is_set_to_zero"), details: { field: [ error.message ] } }, status: :unprocessable_content
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,3 +52,7 @@ en:
       errors:
         record_not_found: "This playable character wasn't found"
         record_not_destroyed: "This playable character wasn't deleted"
+  Api:
+    error:
+      pagination:
+        value_per_page_is_set_to_zero: "The number of elements per page is set to zero it must be greater than zero"

--- a/test/controllers/api/v1/characters_controller_test.rb
+++ b/test/controllers/api/v1/characters_controller_test.rb
@@ -241,4 +241,30 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
 
     assert_includes response.parsed_body[:error], details_message
   end
+
+  test "index should be able to paginate" do
+    get api_v1_characters_url(page: 1, per_page: 3)
+
+    assert_response :success
+    expected_pagination = {
+      next_page: 2,
+      last_page: 2,
+      current_page: 1
+    }
+
+    assert_equal 3, response.parsed_body[:characters].count
+    assert_equal expected_pagination.as_json, response.parsed_body["pagination"].as_json
+
+    get api_v1_characters_url(page: 2, per_page: 2)
+
+    assert_response :success
+    expected_pagination = {
+      next_page: nil,
+      last_page: 2,
+      current_page: 2
+    }
+
+    assert_equal 2, response.parsed_body[:characters].count
+    assert_equal expected_pagination.as_json, response.parsed_body["pagination"].as_json
+  end
 end

--- a/test/controllers/api/v1/characters_controller_test.rb
+++ b/test/controllers/api/v1/characters_controller_test.rb
@@ -253,18 +253,43 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_equal 3, response.parsed_body[:characters].count
-    assert_equal expected_pagination.as_json, response.parsed_body["pagination"].as_json
+    assert_equal expected_pagination.as_json, response.parsed_body[:pagination].as_json
+  end
 
-    get api_v1_characters_url(page: 2, per_page: 2)
+  test "Should be able to paginate and filter " do
+    get api_v1_characters_url(page: 1, per_page: 1, rarity: 4)
 
     assert_response :success
     expected_pagination = {
-      next_page: nil,
+      next_page: 2,
       last_page: 2,
-      current_page: 2
+      current_page: 1
     }
 
-    assert_equal 2, response.parsed_body[:characters].count
-    assert_equal expected_pagination.as_json, response.parsed_body["pagination"].as_json
+    assert_equal 1, response.parsed_body[:characters].count
+    assert_equal [ 4 ], response.parsed_body[:characters].map { |character| character[:rarity] }.uniq
+    assert_equal expected_pagination.as_json, response.parsed_body[:pagination].as_json
+  end
+
+  test "Should render an error message when the parameter 'per_page' is set to zero" do
+    get api_v1_characters_url(page: 1, per_page: 0)
+
+    assert_response :unprocessable_entity
+
+    expected_error_message = I18n.t("Api.error.pagination.value_per_page_is_set_to_zero")
+    expected_details_message = "Current page was incalculable"
+
+    assert_equal expected_error_message.as_json, response.parsed_body[:error]
+
+    assert_includes response.parsed_body[:details][:field].to_s, expected_details_message
+  end
+
+  test "Should return an error message if the value of a parameter has no value or is nil" do
+    get api_v1_characters_url + "?page=nil"
+
+    assert_response :unprocessable_entity
+
+    expected_error_message = "Invalid parameter 'page'"
+    assert_includes response.parsed_body[:error], expected_error_message
   end
 end

--- a/test/controllers/api/v1/characters_controller_test.rb
+++ b/test/controllers/api/v1/characters_controller_test.rb
@@ -253,7 +253,7 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
     }
 
     assert_equal 3, response.parsed_body[:characters].count
-    assert_equal expected_pagination.as_json, response.parsed_body[:pagination].as_json
+    assert_equal expected_pagination.as_json, response.parsed_body[:pagination]
   end
 
   test "Should be able to paginate and filter " do
@@ -268,7 +268,7 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 1, response.parsed_body[:characters].count
     assert_equal [ 4 ], response.parsed_body[:characters].map { |character| character[:rarity] }.uniq
-    assert_equal expected_pagination.as_json, response.parsed_body[:pagination].as_json
+    assert_equal expected_pagination.as_json, response.parsed_body[:pagination]
   end
 
   test "Should render an error message when the parameter 'per_page' is set to zero" do
@@ -291,5 +291,19 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
 
     expected_error_message = "Invalid parameter 'page'"
     assert_includes response.parsed_body[:error], expected_error_message
+  end
+
+  test "Should return an empty array when there are no characters on the page you're on" do
+    get api_v1_characters_url(page: 600, per_page: 4)
+    assert_response :ok
+
+    expected_result = {
+      next_page: nil,
+      last_page: 1,
+      current_page: 600
+     }
+
+    assert_equal [], response.parsed_body[:characters]
+    assert_equal expected_result.as_json, response.parsed_body[:pagination]
   end
 end

--- a/test/controllers/api/v1/characters_controller_test.rb
+++ b/test/controllers/api/v1/characters_controller_test.rb
@@ -248,7 +248,7 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     expected_pagination = {
       next_page: 2,
-      last_page: 2,
+      total_page: 2,
       current_page: 1
     }
 
@@ -262,7 +262,7 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     expected_pagination = {
       next_page: 2,
-      last_page: 2,
+      total_page: 2,
       current_page: 1
     }
 
@@ -299,7 +299,7 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
 
     expected_result = {
       next_page: nil,
-      last_page: 1,
+      total_page: 1,
       current_page: 600
      }
 

--- a/test/controllers/api/v1/characters_controller_test.rb
+++ b/test/controllers/api/v1/characters_controller_test.rb
@@ -246,10 +246,12 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
     get api_v1_characters_url(page: 1, per_page: 3)
 
     assert_response :success
+    characters_per_page = Character.all.page(1).per(3)
+
     expected_pagination = {
-      next_page: 2,
-      total_page: 2,
-      current_page: 1
+      next_page: characters_per_page.next_page,
+      total_page: characters_per_page.total_pages,
+      current_page: characters_per_page.current_page
     }
 
     assert_equal 3, response.parsed_body[:characters].count
@@ -262,7 +264,7 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     expected_pagination = {
       next_page: 2,
-      total_page: 2,
+      total_page: Character.where(rarity: 4).all.page(1).per(1).total_pages,
       current_page: 1
     }
 
@@ -294,7 +296,7 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "Should return an empty array when there are no characters on the page you're on" do
-    get api_v1_characters_url(page: 600, per_page: 4)
+    get api_v1_characters_url(page: 600, per_page: Character.count)
     assert_response :ok
 
     expected_result = {


### PR DESCRIPTION
**Description:** 

- elle va nous permettre de pouvoir faire la pagination sur l'API 
  -  c'est avec un endpoint  comme ça qu'on pourra avoir x éléments par page :
        http://localhost:3000/api/v1/characters?page=1&per_page=2

Et voici les différents cas ( avec screenshot + URL): 

1.  Lorsqu'on a 2 personnages par page : 
http://localhost:3000/api/v1/characters?page=1&per_page=2

<img width="1218" height="783" alt="image" src="https://github.com/user-attachments/assets/a5a7e2a9-8bef-42c9-ae0d-8d071395b0b5" />

2. Quand on veut filter et faire la pagination : 
http://localhost:3000/api/v1/characters?page=1&per_page=2&rarity=4

<img width="1218" height="748" alt="image" src="https://github.com/user-attachments/assets/8d602abc-1e94-4b1b-bfc5-86ca44f28cf1" />

3. Quand on met le nombre d'éléments (le paramètre `per_page`) à zéro, ça nous renvoie un message d'erreur : 
http://localhost:3000/api/v1/characters?page=1&per_page=0&rarity=4

<img width="1223" height="529" alt="image" src="https://github.com/user-attachments/assets/f5f565bf-168d-4abc-b29f-78a3f8b27c3d" />

4. Quand on met des valeurs qui ne sont pas valides d'après la documentation de l'API ça nous renvoie une erreur : 

http://localhost:3000/api/v1/characters?page=nil&per_page=2

<img width="1219" height="422" alt="image" src="https://github.com/user-attachments/assets/e0d4e1a7-963a-4bf9-977c-52f632b5fb97" />

5. Quand on trouve aucun personnage sur la page où on se trouve ça nous retourne un tableau vide : 
http://localhost:3000/api/v1/characters?page=600&per_page=2

<img width="1223" height="458" alt="image" src="https://github.com/user-attachments/assets/ac47bd5c-e5b2-4dc5-8e2a-4430a1add7fd" />

