### PR TITLE
add BossCharacter table

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     lefthook (2.1.10)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.1)
@@ -293,8 +293,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.3)
       actionpack (= 8.1.3)
@@ -530,7 +530,7 @@ CHECKSUMS
   lefthook (2.1.10) sha256=cc9c06bd8ea689e8b8016eab9769e54d696d07951860c1c6d28e8f6812e61b65
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
+  loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
   mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
@@ -573,7 +573,7 @@ CHECKSUMS
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
-  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     lefthook (2.1.10)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.2)
+    loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.1)
@@ -293,8 +293,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.1)
-      loofah (~> 2.25, >= 2.25.2)
+    rails-html-sanitizer (1.7.0)
+      loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.3)
       actionpack (= 8.1.3)
@@ -530,7 +530,7 @@ CHECKSUMS
   lefthook (2.1.10) sha256=cc9c06bd8ea689e8b8016eab9769e54d696d07951860c1c6d28e8f6812e61b65
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
+  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
@@ -573,7 +573,7 @@ CHECKSUMS
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
-  rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
+  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701

--- a/app/models/boss_character.rb
+++ b/app/models/boss_character.rb
@@ -1,0 +1,8 @@
+class BossCharacter < ApplicationRecord
+  include Characterable
+  delegate :name, :description, :rarity, :region, :characterable_type, to: :character, allow_nil: true
+
+  validates :is_weekly_boss, presence: true
+  validates :location, presence: true
+  validates :recommended_level, presence: true
+end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -1,5 +1,5 @@
 class Character < ApplicationRecord
-  delegated_type :characterable, types: %w[ PlayableCharacter ], dependent: :destroy,
+  delegated_type :characterable, types: %w[ PlayableCharacter BossCharacter ], dependent: :destroy,
                  optional: true
   delegate :who_am_i, to: :characterable
 

--- a/db/migrate/20260720125249_create_boss_characters.rb
+++ b/db/migrate/20260720125249_create_boss_characters.rb
@@ -1,0 +1,11 @@
+class CreateBossCharacters < ActiveRecord::Migration[8.1]
+  def change
+    create_table :boss_characters do |t|
+      t.boolean :is_weekly_boss, default: false
+      t.string :location
+      t.integer :recommended_level
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_28_120512) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_20_125249) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "regions", ["Liyue", "Fontaine", "Montstadt"]
+
+  create_table "boss_characters", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "is_weekly_boss", default: false
+    t.string "location"
+    t.integer "recommended_level"
+    t.datetime "updated_at", null: false
+  end
 
   create_table "characters", force: :cascade do |t|
     t.integer "characterable_id"

--- a/test/fixtures/boss_characters.yml
+++ b/test/fixtures/boss_characters.yml
@@ -1,0 +1,23 @@
+stormterror_from_mondsatdt:
+  id: 1016727071
+  is_weekly_boss: true
+  location: Montstadt [Montagnes de Brillecouronne]
+  recommended_level: 18
+
+signora_from_mondsatdt:
+  id: 1016727072
+  is_weekly_boss: true
+  location: Inazuma [l'île Narukami - Tenshukaku]
+  recommended_level: 30
+
+andrius_from_mondsatdt:
+  id: 1016727073
+  is_weekly_boss: true
+  location: Mondstadt [Territoire des Loups]
+  recommended_level: 50
+
+tartaglia_from_mondsatdt:
+  id: 1016727074
+  is_weekly_boss: true
+  location: Liyue [Donjon «Chambre d'Or»]
+  recommended_level: 30

--- a/test/fixtures/characters.yml
+++ b/test/fixtures/characters.yml
@@ -1,6 +1,3 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-
 charlotte_from_fontaine_region :
   name: Charlotte
   description: Charlotte est un personnage Cryo 4 étoile, journaliste pour L'Oiseau de vapeur, le célébre journal de Fontaine
@@ -32,3 +29,43 @@ eula_from_mondsatdt:
   region: Montstadt
   characterable_type: "PlayableCharacter"
   characterable_id: 867337946
+
+stormterror_from_mondsatdt:
+  name: Stormterror
+  description: Stormterror aussi connu sous le nom de Dvalin est le dragon Anémo de l'Est, et un des Quatre Vents de Mondstadt. Il protège Mondstadt et aide Barbatos (l'Archon Anémo) depuis près de 2 000 ans.
+    Le plus pur des joyaux se couvre de poussière lorsqu'il passe de longues années dans l'obscurité. De la même façon, le cœur de ce noble dragon fut rongé par le chagrin et les ténèbres après avoir été empoisonné lors de son combat titanesque contre le dragon noir Durin.
+    Cependant, il existe toujours un moyen de se débarrasser aussi bien de la poussière comme du venin ;  la brise de la liberté et la musique d'un ami fidèle.
+  rarity: 0
+  region: Montstadt
+  characterable_type: "BossCharacter"
+  characterable_id: 1016727071
+
+signora_from_mondsatdt:
+  name: Signora
+  description: Rosalyne-Kruzchka Lohefalter, également appelée Signora ou par son alias « La Demoiselle », était la Huitième Exécutrice des Fatui et une antagoniste de soutien dans les premiers chapitres.
+    Elle est la première Exécutrice à apparaître dans le jeu lorsqu'elle tend une embuscade contre Venti pour lui voler son Gnosis.
+    En fin de compte, elle a perdu contre le Voyageur dans leur duel devant le trône sous les yeux de la Shogun Raiden, et st immédiatement exécutée par la Shogun Raiden d'un coup de sabre dévastateur.
+  rarity: 5
+  region: Montstadt
+  characterable_type: "BossCharacter"
+  characterable_id: 1016727072
+
+andrius_from_mondsatdt:
+  name: Andrius
+  description: Andrius, aussi connu sous le nom de “Loup du Nord” ou “Borée”, est un ancien dieu de Mondstadt et un boss hebdomadaire de Genshin Impact. Il protège le Royaume des Loups et veille avec bienveillance sur Razor.
+    Il est le plus noble et le plus beau des âmes qui veillent sur le Lupical. Quand la meute est en péril, il émerge sous la forme d'un loup d'hydro et de cryo pour montrer ses crocs et ses griffes.
+    Les humains ont rarement l'occasion de croiser le regard d'un loup, ainsi en a décidé le Loup du Nord.
+  rarity: 0
+  region: Montstadt
+  characterable_type: "BossCharacter"
+  characterable_id: 1016727073
+
+tartaglia_from_mondsatdt:
+  name: Tartaglia
+  description: Tartaglia de son vrai nom Ajax, aussi connu sous son nom de code Childe (« Jeune Sire »), est le onzième des Exécuteurs Fatui.
+    Il manie un Œil divin Hydro et peut libérer un sinistre Œil maléfique Électro.Il  combat au moyen d'arts martiaux qu'il a appris dans l'Abîme, une terre couverte par les ténèbres.
+    Chaque conflit sanglant, chaque lutte à mort est une épreuve réjouissante à ses yeux. Certains disent que le jeune Tartaglia est célèbre sur tout le continent pour ses prouesses au combat.
+  rarity: 5
+  region: Montstadt
+  characterable_type: "BossCharacter"
+  characterable_id: 1016727074

--- a/test/models/boss_character_test.rb
+++ b/test/models/boss_character_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class BossCharacterTest < ActiveSupport::TestCase
+  test "Should be able to create a boss character" do
+    boss_character = BossCharacter.create(is_weekly_boss: true, location: "Inazume - [Donjon «Ruines éparses»]", recommended_level: 30)
+    assert boss_character.valid?
+  end
+
+  test "Should not be able to create a boss character if there isn't a location" do
+    boss_character = BossCharacter.create(is_weekly_boss: true, recommended_level: 30)
+    assert_not boss_character.valid?
+  end
+
+  test "Should not be able to create a boss character if there isn't a recommended level" do
+    boss_character = BossCharacter.create(is_weekly_boss: true, location: "Inazume - [Donjon «Ruines éparses»]")
+    assert_not boss_character.valid?
+  end
+
+  test "Should not be able to create a boss character if weekly_boss isn't set to ‘true’ or ‘false’" do
+    boss_character = BossCharacter.create(location: "Inazume - [Donjon «Ruines éparses»]", recommended_level: 30)
+    assert_not boss_character.valid?
+  end
+end


### PR DESCRIPTION
**Description:** 

-  On ajouter 1 nouvelle migration BossCharacter pour stocker dans une nouvelle table toutes les caractéristiques des personnage du type 'Boss'
- Ajouter/Créer un nouveau modèle `BossCharacter `qui hérite du modèle `Character `

Exemple de requête qu'on peut lancer pour avoir un personnage  du type 'boss': 
````
Character.create(name: "tejjt", description: "Un personnage 5 étoiles .", rarity: 1, region: "Montstadt", characterable: BossCharacter.create!(is_weekly_boss: true, location: 'test'))
````

<img width="2960" height="236" alt="image" src="https://github.com/user-attachments/assets/1f53ab37-1e94-4267-bc0d-78390b5bb572" />



