### PR TITLE
use snake_case instead of pascalCase for the locale file

### DIFF
--- a/app/admin/characters.rb
+++ b/app/admin/characters.rb
@@ -19,13 +19,13 @@ ActiveAdmin.register Character do
       actions
     end
 
-  form title: I18n.t("Characters.new.add") do |f|
+  form title: I18n.t("characters.new.add") do |f|
     f.object.errors.full_messages
     inputs "Add a new character" do
-      f.li    I18n.t("Characters.new.info"), style: "font-weight: 750;"
+      f.li    I18n.t("characters.new.info"), style: "font-weight: 750;"
       f.input :name
       f.input :region, as: :select, required: true, collection: Character.regions.keys, style: "width: 50%;", label: "Region"
-      f.input :rarity, as: :number, required: true, placeholder: I18n.t("Characters.errors.number_between_1_5")
+      f.input :rarity, as: :number, required: true, placeholder: I18n.t("characters.errors.number_between_1_5")
       f.input :description, as: :text, required: true
     end
     actions

--- a/app/admin/playable_characters.rb
+++ b/app/admin/playable_characters.rb
@@ -20,17 +20,17 @@ ActiveAdmin.register PlayableCharacter do
     end
   end
 
-  form title: I18n.t("Playable_Characters.new")   do |f|
+  form title: I18n.t("playable_characters.new")   do |f|
     f.object.errors.full_messages
     inputs "Add a new character" do
-      f.li    I18n.t("Characters.new.info"), style: "font-weight: 750;"
+      f.li    I18n.t("characters.new.info"), style: "font-weight: 750;"
       f.input :base_hp, required: true, label: "Base health point", style: "font-weight: 700;"
       f.input :base_defense, required: true
       f.input :base_attack, required: true
       f.input :is_limited, required: true, style: "text-align: center;"
       f.input :name, required: true
       f.input :region, as: :select, required: true, collection: Character.regions.keys, style: "width: 50%;", label: "Region"
-      f.input :rarity, as: :number, required: true, placeholder: I18n.t("Characters.errors.number_between_1_5")
+      f.input :rarity, as: :number, required: true, placeholder: I18n.t("characters.errors.number_between_1_5")
       f.input :description, as: :text, required: true
     end
     actions
@@ -42,10 +42,10 @@ ActiveAdmin.register PlayableCharacter do
         @playable_character =  PlayableCharacter.create!(params.expect([ playable_character: [ :base_hp, :base_defense, :base_attack, :is_limited ] ]))
         @character = Character.create!(params.expect([ playable_character: [ :name, :description, :rarity, :region ] ]).merge(characterable: @playable_character))
       end
-        flash[:notice] = I18n.t("Playable_Characters.create.notice")
+        flash[:notice] = I18n.t("playable_characters.create.notice")
         redirect_to admin_playable_character_path(@playable_character.id)
     rescue ActiveRecord::RecordInvalid => e
-        flash[:alert] = "#{I18n.t("Playable_Characters.create.record_invalid")}, #{e}"
+        flash[:alert] = "#{I18n.t("playable_characters.create.record_invalid")}, #{e}"
         redirect_to new_admin_playable_character_path
     end
 
@@ -53,7 +53,7 @@ ActiveAdmin.register PlayableCharacter do
       ActiveRecord::Base.transaction do
         @playable_character.character.destroy!
       end
-      flash[:notice] = I18n.t("Playable_Characters.destroy.notice")
+      flash[:notice] = I18n.t("playable_characters.destroy.notice")
       redirect_to admin_characters_path
     rescue ActiveRecord::RecordNotDestroyed => e
       flash[:error] = "#{e}, #{ @playable_character.character.errors[:base].to_a.join(' ')}"
@@ -65,10 +65,10 @@ ActiveAdmin.register PlayableCharacter do
        @playable_character.update!(params.expect([ playable_character: [ :base_hp, :base_defense, :base_attack, :is_limited ] ]))
        @playable_character.character.update!(params.expect([ playable_character: [ :name, :description, :rarity, :region ] ]))
       end
-      flash[:notice] = I18n.t("Playable_Characters.update.success")
+      flash[:notice] = I18n.t("playable_characters.update.success")
       redirect_to admin_playable_character_path(@playable_character.id)
     rescue ActiveRecord::RecordInvalid  => e
-      flash[:error] = "#{I18n.t("Playable_Characters.update.record_invalid")}, #{e}"
+      flash[:error] = "#{I18n.t("playable_characters.update.record_invalid")}, #{e}"
       redirect_to edit_admin_playable_character_path
     end
     def find_playable_character

--- a/app/controllers/api/v1/playable_characters_controller.rb
+++ b/app/controllers/api/v1/playable_characters_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::PlayableCharactersController < ApiController
       api :GET, "/api/v1/playable_characters/:id", "render a playable characters"
       api_version "v1"
       returns code: 200
-      error :not_found, I18n.t("Playable_Characters.errors.record_not_found")
+      error :not_found, I18n.t("playable_characters.errors.record_not_found")
 
       def show
         render json: PlayableCharacterJson.new(playable_character: @playable_character).to_h
@@ -35,7 +35,7 @@ class Api::V1::PlayableCharactersController < ApiController
         end
         render json: PlayableCharacterJson.new(playable_character: @playable_character).to_h, status: :created
       rescue ActiveRecord::RecordInvalid => e
-        render status: :unprocessable_entity, json: { error: I18n.t("Playable_Characters.create.record_invalid"), details: { field: [ e.message ] } }
+        render status: :unprocessable_entity, json: { error: I18n.t("playable_characters.create.record_invalid"), details: { field: [ e.message ] } }
       end
 
 
@@ -43,15 +43,15 @@ class Api::V1::PlayableCharactersController < ApiController
       api_version "v1"
       returns code: 200
       error :unprocessable_content, "can't destroy a playable character who's a legendary one"
-      error :not_found, I18n.t("Playable_Characters.errors.record_not_found")
+      error :not_found, I18n.t("playable_characters.errors.record_not_found")
 
       def destroy
         ActiveRecord::Base.transaction do
           @playable_character.character.destroy!
         end
-        render json: { message: I18n.t("Playable_Characters.destroy.notice") }, status: :ok
+        render json: { message: I18n.t("playable_characters.destroy.notice") }, status: :ok
       rescue ActiveRecord::RecordNotDestroyed => e
-        render status: :unprocessable_entity, json: { error: I18n.t("Playable_Characters.errors.record_not_destroyed"), details: { field: [ @playable_character.character.errors[:base].to_a.join(" "), e.message ] } }
+        render status: :unprocessable_entity, json: { error: I18n.t("playable_characters.errors.record_not_destroyed"), details: { field: [ @playable_character.character.errors[:base].to_a.join(" "), e.message ] } }
       end
 
       api :PUT, "/playable_characters/:id", "Update a resource (full replacement)"
@@ -59,7 +59,7 @@ class Api::V1::PlayableCharactersController < ApiController
       api_version "v1"
       returns code: 200
       error :unprocessable_content, "can't update a playable character who doesn't follow the model's validation"
-      error :not_found, I18n.t("Playable_Characters.errors.record_not_found")
+      error :not_found, I18n.t("playable_characters.errors.record_not_found")
 
       def update
         @playable_character.assign_attributes(playable_character_params)
@@ -72,13 +72,13 @@ class Api::V1::PlayableCharactersController < ApiController
         end
         render json: PlayableCharacterJson.new(playable_character: @playable_character).to_h, status: :ok
       rescue ActiveRecord::RecordInvalid=> e
-        render status: :unprocessable_entity, json: { error: I18n.t("Playable_Characters.update.record_invalid"), details: { field: [ e.message ] } }
+        render status: :unprocessable_entity, json: { error: I18n.t("playable_characters.update.record_invalid"), details: { field: [ e.message ] } }
       end
 
       def find_playable_character
         @playable_character = PlayableCharacter.find(params[:id])
       rescue ActiveRecord::RecordNotFound => e
-        render status: :not_found, json: { error:  I18n.t("Playable_Characters.errors.record_not_found"), details: { field: [ e ] } }
+        render status: :not_found, json: { error:  I18n.t("playable_characters.errors.record_not_found"), details: { field: [ e ] } }
       end
 
       def playable_character_params

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -13,6 +13,6 @@ class ApiController < ActionController::Base
     render json: { error: error.message }, status: :unprocessable_content
   end
   def render_pagination_error(error)
-    render json: { error: I18n.t("Api.error.pagination.value_per_page_is_set_to_zero"), details: { field: [ error.message ] } }, status: :unprocessable_content
+    render json: { error: I18n.t("api.error.pagination.value_per_page_is_set_to_zero"), details: { field: [ error.message ] } }, status: :unprocessable_content
   end
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -5,9 +5,9 @@ class Character < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
   validates :description, presence: true,  length: { maximum: 400 }
-  validates :rarity, presence: true, numericality:  { only_integer: true, message: I18n.t("Characters.errors.number_presence") },
-            inclusion: { in: 1..5, message: I18n.t("Characters.errors.number_between_1_5")   }
-  validates :region, presence: { message: I18n.t("Characters.errors.choose_region") }
+  validates :rarity, presence: true, numericality:  { only_integer: true, message: I18n.t("characters.errors.number_presence") },
+            inclusion: { in: 1..5, message: I18n.t("characters.errors.number_between_1_5")   }
+  validates :region, presence: { message: I18n.t("characters.errors.choose_region") }
   enum :region, %w[ Liyue Fontaine Montstadt ].index_by(&:itself)
   before_destroy :check_legendary_character
 
@@ -21,7 +21,7 @@ class Character < ApplicationRecord
 
   def check_legendary_character
     if rarity == 5
-      errors.add(:base, I18n.t("Characters.destroy.should_not_delete_legendary_character"))
+      errors.add(:base, I18n.t("characters.destroy.should_not_delete_legendary_character"))
       throw :abort
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,35 +1,6 @@
-# Files in the config/locales directory are used for internationalization and
-# are automatically loaded by Rails. If you want to use locales other than
-# English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more about the API, please read the Rails Internationalization guide
-# at https://guides.rubyonrails.org/i18n.html.
-#
-# Be aware that YAML interprets the following case-insensitive strings as
-# booleans: `true`, `false`, `on`, `off`, `yes`, `no`. Therefore, these strings
-# must be quoted to be interpreted as strings. For example:
-#
-#     en:
-#       "yes": yup
-#       enabled: "ON"
-
+---
 en:
-  hello: "Hello world"
-  Characters:
+  characters:
       new:
         add: "Add a Character"
         info: "Fill in all the fields about the character "
@@ -39,7 +10,7 @@ en:
         number_presence: "must be a number"
         number_between_1_5: "must be between 1 and 5"
         choose_region: "choose a region from the list, can't be blank"
-  Playable_Characters:
+  playable_characters:
       new: "Add a new  playable character"
       destroy:
         notice: "Character successfully deleted !"
@@ -52,7 +23,7 @@ en:
       errors:
         record_not_found: "This playable character wasn't found"
         record_not_destroyed: "This playable character wasn't deleted"
-  Api:
+  api:
     error:
       pagination:
         value_per_page_is_set_to_zero: "The number of elements per page is set to zero it must be greater than zero"

--- a/test/controllers/admin/playable_characters_controller_test.rb
+++ b/test/controllers/admin/playable_characters_controller_test.rb
@@ -25,7 +25,7 @@ class Admin::PlayableCharactersControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
 
     assert_redirected_to admin_playable_character_path(PlayableCharacter.last.id)
-    assert_includes flash[:notice], I18n.t("Playable_Characters.create.notice")
+    assert_includes flash[:notice], I18n.t("playable_characters.create.notice")
 
     assert_equal  PlayableCharacter.last&.base_hp.to_f, 150.0
     assert_equal  PlayableCharacter.last&.name.to_s, "Fischl"
@@ -74,7 +74,7 @@ class Admin::PlayableCharactersControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_admin_playable_character_path
 
-    assert_includes flash[:alert], I18n.t("Playable_Characters.create.record_invalid")
+    assert_includes flash[:alert], I18n.t("playable_characters.create.record_invalid")
   end
 
   test "we shouldn't be able to create a playable characters if the playable character's field are not valid" do
@@ -96,7 +96,7 @@ class Admin::PlayableCharactersControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_admin_playable_character_path
 
-    assert_includes flash[:alert], I18n.t("Playable_Characters.create.record_invalid")
+    assert_includes flash[:alert], I18n.t("playable_characters.create.record_invalid")
   end
   test "Should be able to delete a playable character" do
     character = playable_characters(:yanfei_from_fontaine_region)
@@ -108,7 +108,7 @@ class Admin::PlayableCharactersControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to admin_characters_path
 
-    assert_includes flash[:notice], I18n.t("Playable_Characters.destroy.notice")
+    assert_includes flash[:notice], I18n.t("playable_characters.destroy.notice")
   end
 
   test "Shouldn't be able to delete a playable character who is a 5 star" do
@@ -121,7 +121,7 @@ class Admin::PlayableCharactersControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to admin_characters_path
 
-    assert_includes flash[:error], I18n.t("Characters.destroy.should_not_delete_legendary_character")
+    assert_includes flash[:error], I18n.t("characters.destroy.should_not_delete_legendary_character")
   end
 
   test "Should be able to update a playable character if we change the value of a field using a PATCH request" do
@@ -144,7 +144,7 @@ class Admin::PlayableCharactersControllerTest < ActionDispatch::IntegrationTest
 
     playable_character.reload
 
-    assert_includes flash[:notice], I18n.t("Playable_Characters.update.success")
+    assert_includes flash[:notice], I18n.t("playable_characters.update.success")
 
     assert_equal 150.0, playable_character.base_hp
     assert_equal "Fontaine", playable_character.character.region
@@ -170,7 +170,7 @@ class Admin::PlayableCharactersControllerTest < ActionDispatch::IntegrationTest
 
     playable_character.reload
 
-    assert_includes flash[:notice], I18n.t("Playable_Characters.update.success")
+    assert_includes flash[:notice], I18n.t("playable_characters.update.success")
 
     assert_equal 159.0, playable_character.base_hp
     assert_equal "Liyue", playable_character.character.region
@@ -194,7 +194,7 @@ class Admin::PlayableCharactersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_admin_playable_character_path
 
     playable_character.reload
-    assert_includes flash[:error], I18n.t("Playable_Characters.update.record_invalid")
+    assert_includes flash[:error], I18n.t("playable_characters.update.record_invalid")
 
     assert_equal "Liyue", playable_character.region
     assert_equal 20.12, playable_character.base_attack
@@ -220,7 +220,7 @@ class Admin::PlayableCharactersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_admin_playable_character_path
 
     playable_character.reload
-    assert_includes flash[:error], I18n.t("Playable_Characters.update.record_invalid")
+    assert_includes flash[:error], I18n.t("playable_characters.update.record_invalid")
 
     assert_equal "Fontaine", playable_character.region
     assert_equal 14.51, playable_character.base_attack
@@ -239,7 +239,7 @@ class Admin::PlayableCharactersControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to edit_admin_playable_character_path
 
-    assert_includes flash[:error], I18n.t("Playable_Characters.update.record_invalid")
+    assert_includes flash[:error], I18n.t("playable_characters.update.record_invalid")
 
     assert_equal 18.99, playable_character.base_attack
     assert_not_equal 50, playable_character.base_attack
@@ -257,7 +257,7 @@ class Admin::PlayableCharactersControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to edit_admin_playable_character_path
 
-    assert_includes flash[:error], I18n.t("Playable_Characters.update.record_invalid")
+    assert_includes flash[:error], I18n.t("playable_characters.update.record_invalid")
     assert_equal 14.51, playable_character.base_attack
     assert_not_equal 50, playable_character.base_attack
   end

--- a/test/controllers/api/v1/characters_controller_test.rb
+++ b/test/controllers/api/v1/characters_controller_test.rb
@@ -107,7 +107,7 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
 
-    error_message = I18n.t("Characters.destroy.should_not_delete_legendary_character")
+    error_message = I18n.t("characters.destroy.should_not_delete_legendary_character")
 
     assert_includes response.parsed_body[:message], error_message.as_json
   end
@@ -278,7 +278,7 @@ class Api::V1::CharactersControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
 
-    expected_error_message = I18n.t("Api.error.pagination.value_per_page_is_set_to_zero")
+    expected_error_message = I18n.t("api.error.pagination.value_per_page_is_set_to_zero")
     expected_details_message = "Current page was incalculable"
 
     assert_equal expected_error_message.as_json, response.parsed_body[:error]

--- a/test/controllers/api/v1/playable_characters_controller_test.rb
+++ b/test/controllers/api/v1/playable_characters_controller_test.rb
@@ -31,7 +31,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :not_found
 
-    error_message = I18n.t("Playable_Characters.errors.record_not_found")
+    error_message = I18n.t("playable_characters.errors.record_not_found")
 
     assert_includes response.parsed_body[:error], error_message.as_json
   end
@@ -73,7 +73,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :unprocessable_entity
 
-    error_message = { error: I18n.t("Playable_Characters.create.record_invalid"), details: { field: [ "Validation failed: Base hp can't be blank" ] } }
+    error_message = { error: I18n.t("playable_characters.create.record_invalid"), details: { field: [ "Validation failed: Base hp can't be blank" ] } }
 
     assert_equal response.parsed_body, error_message.as_json
 
@@ -96,7 +96,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :unprocessable_entity
 
-    error_message = { error: I18n.t("Playable_Characters.create.record_invalid"), details: { field: [ "Validation failed: Name can't be blank" ] } }
+    error_message = { error: I18n.t("playable_characters.create.record_invalid"), details: { field: [ "Validation failed: Name can't be blank" ] } }
 
     assert_equal response.parsed_body, error_message.as_json
 
@@ -119,7 +119,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :unprocessable_entity
 
-    error_message = { error: I18n.t("Playable_Characters.create.record_invalid"), details: { field: [ "Validation failed: Name has already been taken" ] } }
+    error_message = { error: I18n.t("playable_characters.create.record_invalid"), details: { field: [ "Validation failed: Name has already been taken" ] } }
 
     assert_equal response.parsed_body, error_message.as_json
 
@@ -136,7 +136,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :ok
 
-    assert_equal response.parsed_body[:message], I18n.t("Playable_Characters.destroy.notice")
+    assert_equal response.parsed_body[:message], I18n.t("playable_characters.destroy.notice")
   end
 
   test "Shouldn't be able to delete a playable character who doesn't exist in the database" do
@@ -146,7 +146,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
 
    assert_response :not_found
 
-    assert_equal response.parsed_body[:error], I18n.t("Playable_Characters.errors.record_not_found").as_json
+    assert_equal response.parsed_body[:error], I18n.t("playable_characters.errors.record_not_found").as_json
   end
 
 
@@ -159,7 +159,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :unprocessable_entity
 
-    assert_includes response.parsed_body[:details][:field], I18n.t("Characters.destroy.should_not_delete_legendary_character").as_json
+    assert_includes response.parsed_body[:details][:field], I18n.t("characters.destroy.should_not_delete_legendary_character").as_json
   end
 
   test "Should be able to update a playable character using a PATCH request" do
@@ -217,7 +217,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :unprocessable_entity
 
-    error_message = I18n.t("Playable_Characters.update.record_invalid")
+    error_message = I18n.t("playable_characters.update.record_invalid")
 
     assert_includes response.parsed_body[:error], error_message.as_json
 
@@ -240,7 +240,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :unprocessable_entity
 
-    error_message = I18n.t("Playable_Characters.update.record_invalid")
+    error_message = I18n.t("playable_characters.update.record_invalid")
 
     assert_includes response.parsed_body[:error], error_message.as_json
 
@@ -253,7 +253,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
     patch api_v1_playable_character_url(id: playable_character.id), params: { base_hp: "", ie_limited: false }
     assert_response :unprocessable_entity
 
-    error_message = I18n.t("Playable_Characters.update.record_invalid")
+    error_message = I18n.t("playable_characters.update.record_invalid")
 
     assert_equal response.parsed_body[:error], error_message.as_json
 
@@ -275,7 +275,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
         }
     assert_response :unprocessable_entity
 
-    error_message = I18n.t("Playable_Characters.update.record_invalid")
+    error_message = I18n.t("playable_characters.update.record_invalid")
 
     assert_equal response.parsed_body[:error], error_message.as_json
 
@@ -289,7 +289,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :unprocessable_entity
 
-    error_message = I18n.t("Playable_Characters.update.record_invalid")
+    error_message = I18n.t("playable_characters.update.record_invalid")
 
     assert_equal response.parsed_body[:error], error_message.as_json
 
@@ -313,7 +313,7 @@ class Api::V1::PlayableCharactersControllerTest < ActionDispatch::IntegrationTes
 
     assert_response :unprocessable_entity
 
-    error_message = I18n.t("Playable_Characters.update.record_invalid")
+    error_message = I18n.t("playable_characters.update.record_invalid")
 
     assert_equal response.parsed_body[:error], error_message.as_json
 


### PR DESCRIPTION
**Description:** 

-  Suite à ce [commentaire](https://github.com/maryam-amn/genshin-wiki-api/pull/79#discussion_r3622448843), j'ai créé cette PR pour corriger un fichier (qui va nous afficher un texte suivant la locale qu'on a) en mettant le nom des variables de la locale en minuscules ( Avant elles commençaient toutes en majuscules)  