### PR TITLE
redirect to the bosscharacter controller when the type of character is a boss 

### DIFF
--- a/app/admin/boss_characters.rb
+++ b/app/admin/boss_characters.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register BossCharacter do
+   menu false
+end

--- a/app/admin/characters.rb
+++ b/app/admin/characters.rb
@@ -1,7 +1,6 @@
 ActiveAdmin.register Character do
   permit_params :name, :region, :rarity, :description, :character_id
   before_action :find_character, only: [ :show, :edit ]
-
   actions :all, except: [ :destroy, :update ]
   filter :rarity
   filter :region, as: :select, collection: proc { Character.regions.keys }
@@ -14,7 +13,9 @@ ActiveAdmin.register Character do
       column :name
       column :region
       column :rarity
-      column :description
+      column :description do |character|
+        character.description.truncate(150)
+      end
       column :characterable_type
       actions
     end
@@ -35,12 +36,16 @@ ActiveAdmin.register Character do
       def show
         if @character.characterable_type == "PlayableCharacter"
           redirect_to admin_playable_character_path(id: @character.characterable_id)
+        elsif @character.characterable_type == "BossCharacter"
+          redirect_to admin_boss_character_path(id: @character.characterable_id)
         end
       end
 
       def edit
         if @character.characterable_type == "PlayableCharacter"
           redirect_to edit_admin_playable_character_path(id: @character.characterable_id)
+        elsif @character.characterable_type == "BossCharacter"
+          redirect_to edit_admin_boss_character_path(id: @character.characterable_id)
         end
       end
 

--- a/test/controllers/admin/characters_controller_test.rb
+++ b/test/controllers/admin/characters_controller_test.rb
@@ -3,9 +3,11 @@ require "test_helper"
 class Admin::CharactersControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test "Should get index and show information of all characters when the user is logged in " do
+  setup do
     sign_in users(:admin_users)
+  end
 
+  test "Should get index and show information of all characters when the user is logged in " do
     get admin_characters_url
 
     assert_response :success
@@ -24,8 +26,6 @@ class Admin::CharactersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "we should be able to create a new user" do
-    sign_in users(:admin_users)
-
     assert_difference -> { Character.count } => +1 do
       post admin_characters_path, params: {
         character: {
@@ -58,8 +58,6 @@ class Admin::CharactersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "Can't create a new character when a field is blank " do
-    sign_in users(:admin_users)
-
     character = Character.new(name: "Ganyu", region: "Liyue", description: "un personnage 5 étoiles", rarity: "")
 
     assert_predicate character, :invalid?
@@ -69,12 +67,42 @@ class Admin::CharactersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "Should redirect to the playable character show page" do
-    sign_in users(:admin_users)
-    character = characters(:charlotte_from_fontaine_region)
+    playable_character = characters(:charlotte_from_fontaine_region)
 
-    get admin_character_url(character.id)
+    get admin_character_url(playable_character.id)
 
     assert_response :redirect
-    assert_redirected_to admin_playable_character_path(character.id)
+
+    assert_redirected_to admin_playable_character_path(playable_character.characterable_id)
+  end
+
+  test "Should redirect to the playable character edit page when a user is logged in" do
+    playable_character = characters(:charlotte_from_fontaine_region)
+
+    get edit_admin_character_url(playable_character.id)
+
+    assert_response :redirect
+
+    assert_redirected_to edit_admin_playable_character_path(playable_character.characterable_id)
+  end
+
+  test "Should redirect to the boss character show page" do
+    boss_character = characters(:signora_from_mondsatdt)
+
+    get admin_character_url(boss_character.id)
+
+    assert_response :redirect
+
+    assert_redirected_to admin_boss_character_path(boss_character.characterable_id)
+  end
+
+  test "Should redirect to the boss edit page when a user is logged in" do
+    boss_character = characters(:signora_from_mondsatdt)
+
+    get edit_admin_character_url(boss_character.id)
+
+    assert_response :redirect
+
+    assert_redirected_to edit_admin_boss_character_path(boss_character.characterable_id)
   end
 end


### PR DESCRIPTION
**Description:** 

- Rediriger sur la route 'admin/boss_character/:id' si le type du personnage est `BossCharacter `
- Vérifier que le filtre 'type' marche bien quand on choisit le type `BossCharacter `


Avec le filtre `type` quand on choisit `BossCharacter`  

<img width="1919" height="783" alt="image" src="https://github.com/user-attachments/assets/bb6a3e7b-b620-431e-b665-3f7bb78dfe6a" />



Quand j'appuie sur 'View', ça me redirige sur` 'admin/boss_character/:id'`

<img width="1481" height="253" alt="image" src="https://github.com/user-attachments/assets/02aa5e00-ccb1-4e24-a4b8-ce574e6652d3" />

<img width="1913" height="628" alt="image" src="https://github.com/user-attachments/assets/6a0ed045-a038-419e-a152-e7139c07f40a" />

 