### PR TITLE
add a form to be able to create a boss character closes #89

### DIFF
--- a/app/admin/boss_characters.rb
+++ b/app/admin/boss_characters.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register BossCharacter do
    menu false
 
-   permit_params :is_weekly_boss, :recommended_level, :exact_location, :region_location
+   permit_params :is_weekly_boss, :recommended_level, :fight_region_location, :fight_exact_location
    actions :all, except: [ :destroy, :update ]
 
    show do
@@ -19,20 +19,20 @@ ActiveAdmin.register BossCharacter do
       end
    end
 
-   form title: I18n.t("boss_character.new.create_title") do |f|
+   form title: I18n.t("boss_characters.new.create_title") do |f|
       f.semantic_errors
-      f.inputs I18n.t("boss_character.new.details_character") do
+      f.inputs I18n.t("boss_characters.new.details_character") do
          f.input :name
          f.input :region, as: :select, collection: Character.regions.keys
          f.input :description, as: :text
          f.input :rarity, as: :number
-         f.inputs I18n.t("boss_character.new.details_boss") do
-            f.li "#{I18n.t("boss_character.new.location_notice")}".html_safe, style: "font-weight: 650; color: grey"
-            f.input :recommended_level, as: :number
-            f.input :region_location, label: "Region of the location", as: :select, collection: Character.regions.keys, required: true
-            f.input :exact_location, label: "Specific localisation", as: :string, required: true
-            f.input :is_weekly_boss, as: :select, include_blank: false
-         end
+      end
+      f.inputs I18n.t("boss_characters.new.details_boss") do
+         f.input :recommended_level, as: :number
+         f.li "#{I18n.t("boss_characters.new.fill_in_the_fight_location_of_a_boss")}", style: "font-weight: 650; color: grey"
+         f.input :fight_region_location, as: :select, required: true, collection: BossCharacter.fight_region_locations.keys
+         f.input :fight_exact_location, as: :string, required: true, label: "Specific location"
+         f.input :is_weekly_boss, as: :select, include_blank: false
       end
       actions
    end
@@ -43,15 +43,15 @@ ActiveAdmin.register BossCharacter do
            @boss_character = BossCharacter.create!(boss_permitted_params)
            @character = Character.create!(character_permitted_params.merge(characterable: @boss_character))
          end
-         flash[:notice] = I18n.t("boss_character.new.notice")
+         flash[:notice] = I18n.t("boss_characters.new.notice")
          redirect_to admin_boss_character_path(@boss_character.id)
       rescue ActiveRecord::RecordInvalid => e
-         flash[:error] = "#{I18n.t("boss_character.new.record_invalid")}, #{e} "
+         flash[:error] = "#{I18n.t("boss_characters.new.record_invalid")}, #{e} "
          redirect_to new_admin_boss_character_url
       end
 
       def boss_permitted_params
-         params.expect(boss_character: [ :is_weekly_boss, :recommended_level, :region_location, :exact_location ])
+         params.expect(boss_character: [ :is_weekly_boss, :recommended_level, :fight_region_location, :fight_exact_location ])
       end
       def character_permitted_params
           params.expect([ boss_character: [ :name, :description, :rarity, :region ] ])

--- a/app/admin/boss_characters.rb
+++ b/app/admin/boss_characters.rb
@@ -1,7 +1,8 @@
 ActiveAdmin.register BossCharacter do
    menu false
 
-   permit_params :is_weekly_boss, :location, :recommended_level
+   permit_params :is_weekly_boss, :recommended_level, :exact_location, :region_location
+   actions :all, except: [ :destroy, :update ]
 
    show do
       attributes_table do
@@ -14,6 +15,45 @@ ActiveAdmin.register BossCharacter do
          row :is_weekly_boss
          row :recommended_level
          row :created_at
+      end
+   end
+
+   form title: I18n.t("boss_character.new.create_title") do |f|
+      f.semantic_errors
+      f.inputs I18n.t("boss_character.new.details_character") do
+         f.input :name
+         f.input :region, as: :select, collection: Character.regions.keys
+         f.input :description, as: :text
+         f.input :rarity, as: :number
+         f.inputs I18n.t("boss_character.new.details_boss") do
+            f.li "#{I18n.t("boss_character.new.location_notice")}".html_safe, style: "font-weight: 650; color: grey"
+            f.input :recommended_level, as: :number
+            f.input :region_location, label: "Region of the location", as: :select, collection: Character.regions.keys, required: true
+            f.input :exact_location, label: "Specific localisation", as: :string, required: true
+            f.input :is_weekly_boss, as: :select, include_blank: false
+         end
+      end
+      actions
+   end
+
+   controller do
+      def create
+        ActiveRecord::Base.transaction do
+           @boss_character = BossCharacter.create!(boss_permitted_params)
+           @character = Character.create!(character_permitted_params.merge(characterable: @boss_character))
+         end
+         flash[:notice] = I18n.t("boss_character.new.notice")
+         redirect_to admin_boss_character_path(@boss_character.id)
+      rescue ActiveRecord::RecordInvalid => e
+         flash[:error] = "#{I18n.t("boss_character.new.record_invalid")}, #{e} "
+         redirect_to new_admin_boss_character_url
+      end
+
+      def boss_permitted_params
+         params.expect(boss_character: [ :is_weekly_boss, :recommended_level, :region_location, :exact_location ])
+      end
+      def character_permitted_params
+          params.expect([ boss_character: [ :name, :description, :rarity, :region ] ])
       end
    end
 end

--- a/app/admin/boss_characters.rb
+++ b/app/admin/boss_characters.rb
@@ -32,7 +32,7 @@ ActiveAdmin.register BossCharacter do
          f.li "#{I18n.t("boss_characters.new.fill_in_the_fight_location_of_a_boss")}", style: "font-weight: 650; color: grey"
          f.input :fight_region_location, as: :select, required: true, collection: BossCharacter.fight_region_locations.keys
          f.input :fight_exact_location, as: :string, required: true, label: "Specific location"
-         f.input :is_weekly_boss, as: :select, include_blank: false
+         f.input :is_weekly_boss, as: :radio
       end
       actions
    end

--- a/app/admin/characters.rb
+++ b/app/admin/characters.rb
@@ -7,6 +7,10 @@ ActiveAdmin.register Character do
   filter :characterable_type, as: :select, collection: proc { Character.characterable_types }, label: "Characters Type"
 
   action_item :get, only: :index  do
+    link_to I18n.t("boss_character.new.create_title"), new_admin_boss_character_path
+  end
+
+  action_item :get, only: :index  do
     link_to "New playable a character", new_admin_playable_character_path
   end
     index do

--- a/app/admin/characters.rb
+++ b/app/admin/characters.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register Character do
   filter :characterable_type, as: :select, collection: proc { Character.characterable_types }, label: "Characters Type"
 
   action_item :get, only: :index  do
-    link_to I18n.t("boss_character.new.create_title"), new_admin_boss_character_path
+    link_to I18n.t("boss_characters.new.create_title"), new_admin_boss_character_path
   end
 
   action_item :get, only: :index  do

--- a/app/models/boss_character.rb
+++ b/app/models/boss_character.rb
@@ -2,7 +2,22 @@ class BossCharacter < ApplicationRecord
   include Characterable
   delegate :name, :description, :rarity, :region, :characterable_type, to: :character, allow_nil: true
 
-  validates :is_weekly_boss, presence: true
+  validates :is_weekly_boss, presence: true, inclusion: { within: [ true, false ] }
   validates :location, presence: true
   validates :recommended_level, presence: true
+
+  attr_accessor :region_location, :exact_location
+
+  validates :region_location, inclusion: { in: [ "Liyue", "Fontaine", "Monstadt" ] }, allow_blank: true
+  validates :exact_location, format: { with: /\A[a-zA-Z0-9 ]+\z/ }, allow_blank: true
+
+  before_validation :set_location
+
+  def set_location
+    if region_location.present? && exact_location.present?
+      self.location = "#{region_location} - #{exact_location}"
+    else
+      self.location
+    end
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,14 @@
 
 en:
   hello: "Hello world"
+  boss_character:
+      new:
+        create_title: "Create a new boss character"
+        details_boss: "Details of the boss character"
+        details_character: "Details of a character"
+        location_notice: "Fill in the fields about the boss character :"
+        notice: "The boss character was successfully created !"
+        record_invalid: "The boss character can't be created"
   Characters:
       new:
         add: "Add a Character"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,13 +4,13 @@ en:
     model_message_errors:
       must_be_presence_of_fight_region_location: "choose a region from the list, we need it to know where to fight him/her"
       character_presence: "There must the exact location, please fill in the field"
-      new:
-        create_title: "Create a new boss character"
-        details_boss: "Details of the boss character"
-        details_character: "Details of a character"
-        location_notice: "Fill in the fields about the boss character :"
-        notice: "The boss character was successfully created !"
-        record_invalid: "The boss character can't be created"
+    new:
+      create_title: "Create a new boss character"
+      details_boss: "Details of a boss character"
+      details_character: "Details of a character"
+      fill_in_the_fight_location_of_a_boss: "Fill in to find out where the character can be found"
+      notice: "The boss character was successfully created !"
+      record_invalid: "The boss character can't be created"
   characters:
       new:
         add: "Add a Character"

--- a/test/controllers/admin/boss_characters_controller_test.rb
+++ b/test/controllers/admin/boss_characters_controller_test.rb
@@ -31,18 +31,18 @@ class Admin::BossCharactersControllerTest < ActionDispatch::IntegrationTest
 
   test "Should create a new boss character if all the fields have been completed" do
     assert_difference -> { Character.count } => +1, -> { BossCharacter.count } => +1 do
-    post admin_boss_characters_path, params: {
-      boss_character: {
-        name: "Fischl",
-        region: "Montstadt",
-        rarity: 3,
-        description: "un personnage 3 étoiles",
-        is_weekly_boss: true,
-        recommended_level: 50,
-        fight_region_location: "Fontaine",
-        fight_exact_location: "la chambre des secret"
+      post admin_boss_characters_path, params: {
+        boss_character: {
+          name: "Fischl",
+          region: "Montstadt",
+          rarity: 3,
+          description: "un personnage 3 étoiles",
+          is_weekly_boss: true,
+          recommended_level: 50,
+          fight_region_location: "Fontaine",
+          fight_exact_location: "la chambre des secret"
+        }
       }
-    }
     end
 
     assert_response :redirect
@@ -57,19 +57,19 @@ class Admin::BossCharactersControllerTest < ActionDispatch::IntegrationTest
 
   test "Shouldn't be able to create a boss character if the character's field aren't valid" do
     assert_difference -> { Character.count } => 0, -> { BossCharacter.count } => 0 do
-    post admin_boss_characters_path, params: {
-      boss_character: {
-        name: "Fischl",
-        region: "",
-        rarity: "",
-        description: "un personnage 3 étoiles",
-        is_weekly_boss: true,
-        recommended_level: 50,
-        fight_region_location: "Fontaine",
-        fight_exact_location: "la chambre des secret "
+      post admin_boss_characters_path, params: {
+        boss_character: {
+          name: "Fischl",
+          region: "",
+          rarity: "",
+          description: "un personnage 3 étoiles",
+          is_weekly_boss: true,
+          recommended_level: 50,
+          fight_region_location: "Fontaine",
+          fight_exact_location: "la chambre des secret "
+        }
       }
-    }
-    end
+      end
 
     assert_response :redirect
 
@@ -80,18 +80,18 @@ class Admin::BossCharactersControllerTest < ActionDispatch::IntegrationTest
 
   test "Shouldn't be able to create a boss character if the boss's filed aren't valid" do
     assert_difference -> { Character.count } => 0, -> { BossCharacter.count } => 0 do
-    post admin_boss_characters_path, params: {
-      boss_character: {
-        name: "Fischl",
-        region: "Fontaine",
-        rarity: 2,
-        description: "un personnage 3 étoiles",
-        is_weekly_boss: true,
-        recommended_level: "",
-        fight_region_location: "Montstadt",
-        fight_exact_location: ""
+      post admin_boss_characters_path, params: {
+        boss_character: {
+          name: "Fischl",
+          region: "Fontaine",
+          rarity: 2,
+          description: "un personnage 3 étoiles",
+          is_weekly_boss: true,
+          recommended_level: "",
+          fight_region_location: "Montstadt",
+          fight_exact_location: ""
+        }
       }
-    }
     end
 
     assert_response :redirect

--- a/test/controllers/admin/boss_characters_controller_test.rb
+++ b/test/controllers/admin/boss_characters_controller_test.rb
@@ -28,4 +28,74 @@ class Admin::BossCharactersControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_redirected_to new_user_session_path
   end
+
+  test "Should create a new boss character if all the fields have been completed" do
+    assert_difference -> { Character.count } => +1, -> { BossCharacter.count } => +1 do
+    post admin_boss_characters_path, params: {
+      boss_character: {
+        name: "Fischl",
+        region: "Montstadt",
+        rarity: 3,
+        description: "un personnage 3 étoiles",
+        is_weekly_boss: true,
+        recommended_level: 50,
+        region_location: "Fontaine",
+        exact_location: "la chambre des secret"
+      }
+    }
+    end
+
+    assert_response :redirect
+
+    assert_redirected_to admin_boss_character_path(BossCharacter.last.id)
+
+    assert_equal flash[:notice], I18n.t("boss_character.new.notice")
+
+    assert_equal  BossCharacter.last&.recommended_level, 50
+    assert_equal  BossCharacter.last&.name.to_s, "Fischl"
+  end
+
+  test "Shouldn't be able to create a boss character if the character's field aren't valid" do
+    assert_difference -> { Character.count } => 0, -> { BossCharacter.count } => 0 do
+    post admin_boss_characters_path, params: {
+      boss_character: {
+        name: "Fischl",
+        region: "",
+        rarity: "",
+        description: "un personnage 3 étoiles",
+        is_weekly_boss: true,
+        recommended_level: 50,
+        region_location: "Fontaine",
+        exact_location: "la chambre des secret "
+      }
+    }
+    end
+
+    assert_response :redirect
+
+    assert_redirected_to new_admin_boss_character_path
+
+    assert_includes flash[:error], "#{I18n.t("boss_character.new.record_invalid")}, Validation failed:"
+  end
+
+  test "Shouldn't be able to create a boss character if the boss's filed aren't valid" do
+    assert_difference -> { Character.count } => 0, -> { BossCharacter.count } => 0 do
+    post admin_boss_characters_path, params: {
+      boss_character: {
+        name: "Fischl",
+        region: "Fontaine",
+        rarity: 2,
+        description: "un personnage 3 étoiles",
+        is_weekly_boss: true,
+        recommended_level: "",
+        region_location: "ffff",
+        exact_location: ""
+      }
+    }
+    end
+
+    assert_response :redirect
+    assert_redirected_to new_admin_boss_character_path
+    assert_includes flash[:error], "#{I18n.t("boss_character.new.record_invalid")}, Validation failed:"
+  end
 end

--- a/test/controllers/admin/boss_characters_controller_test.rb
+++ b/test/controllers/admin/boss_characters_controller_test.rb
@@ -39,8 +39,8 @@ class Admin::BossCharactersControllerTest < ActionDispatch::IntegrationTest
         description: "un personnage 3 étoiles",
         is_weekly_boss: true,
         recommended_level: 50,
-        region_location: "Fontaine",
-        exact_location: "la chambre des secret"
+        fight_region_location: "Fontaine",
+        fight_exact_location: "la chambre des secret"
       }
     }
     end
@@ -49,7 +49,7 @@ class Admin::BossCharactersControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to admin_boss_character_path(BossCharacter.last.id)
 
-    assert_equal flash[:notice], I18n.t("boss_character.new.notice")
+    assert_equal flash[:notice], I18n.t("boss_characters.new.notice")
 
     assert_equal  BossCharacter.last&.recommended_level, 50
     assert_equal  BossCharacter.last&.name.to_s, "Fischl"
@@ -65,8 +65,8 @@ class Admin::BossCharactersControllerTest < ActionDispatch::IntegrationTest
         description: "un personnage 3 étoiles",
         is_weekly_boss: true,
         recommended_level: 50,
-        region_location: "Fontaine",
-        exact_location: "la chambre des secret "
+        fight_region_location: "Fontaine",
+        fight_exact_location: "la chambre des secret "
       }
     }
     end
@@ -75,7 +75,7 @@ class Admin::BossCharactersControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to new_admin_boss_character_path
 
-    assert_includes flash[:error], "#{I18n.t("boss_character.new.record_invalid")}, Validation failed:"
+    assert_includes flash[:error], "#{I18n.t("boss_characters.new.record_invalid")}, Validation failed:"
   end
 
   test "Shouldn't be able to create a boss character if the boss's filed aren't valid" do
@@ -88,14 +88,14 @@ class Admin::BossCharactersControllerTest < ActionDispatch::IntegrationTest
         description: "un personnage 3 étoiles",
         is_weekly_boss: true,
         recommended_level: "",
-        region_location: "ffff",
-        exact_location: ""
+        fight_region_location: "Montstadt",
+        fight_exact_location: ""
       }
     }
     end
 
     assert_response :redirect
     assert_redirected_to new_admin_boss_character_path
-    assert_includes flash[:error], "#{I18n.t("boss_character.new.record_invalid")}, Validation failed:"
+    assert_includes flash[:error], "#{I18n.t("boss_characters.new.record_invalid")}, Validation failed:"
   end
 end


### PR DESCRIPTION
**Description:** 

- Ajouter un nouveau formulaire pour pouvoir créer un nouveau personnage, après la création on est redirigée sur la page de détails du personnage créé



Les différents cas : 

1, Dans le cas où tous les champs sont remplis : 

<img width="1615" height="912" alt="image" src="https://github.com/user-attachments/assets/95e074eb-138b-47de-a180-b2518c13d349" />


2. Dans le cas où il y a un champ qui n'est pas rempli : 


<img width="1618" height="840" alt="image" src="https://github.com/user-attachments/assets/8b815817-4d27-4f58-9bc8-4651f363332e" />

