### PR TITLE
add 2 columns to the table 'boss_characters', and remove the columns 'location'

### DIFF
--- a/app/admin/boss_characters.rb
+++ b/app/admin/boss_characters.rb
@@ -10,7 +10,8 @@ ActiveAdmin.register BossCharacter do
          row :description
          row :region
          row :rarity
-         row :location
+         row :location do |boss|
+            "#{boss.fight_region_location} - #{boss.fight_exact_location}" end
          row :is_weekly_boss
          row :recommended_level
          row :created_at

--- a/app/models/boss_character.rb
+++ b/app/models/boss_character.rb
@@ -2,7 +2,10 @@ class BossCharacter < ApplicationRecord
   include Characterable
   delegate :name, :description, :rarity, :region, :characterable_type, to: :character, allow_nil: true
 
-  validates :is_weekly_boss, presence: true
-  validates :location, presence: true
   validates :recommended_level, presence: true
+  enum :fight_region_location, %w[ Liyue Montstadt Inazuma Sumeru Fontaine Natlan Nod-Krai Snezhnaya Khaenri'ah].index_by(&:itself)
+
+  validates :fight_region_location, presence: { message: I18n.t("boss_characters.model_message_errors.must_be_presence_of_fight_region_location") }
+  validates :fight_exact_location, format: { without: /[!@#$%^*()-=_+|;:<>?]/ },
+            presence: { message: I18n.t("boss_characters.model_message_errors.character_presence") }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,9 @@
 ---
 en:
+  boss_characters:
+    model_message_errors:
+      must_be_presence_of_fight_region_location: "choose a region from the list, we need it to know where to fight him/her"
+      character_presence: "There must the exact location, please fill in the field"
   characters:
       new:
         add: "Add a Character"

--- a/db/migrate/20260730122410_change_column_boss_character_location.rb
+++ b/db/migrate/20260730122410_change_column_boss_character_location.rb
@@ -1,0 +1,9 @@
+class ChangeColumnBossCharacterLocation < ActiveRecord::Migration[8.1]
+  def change
+    create_enum :fight_region_locations, %w[ Liyue Montstadt Inazuma Sumeru Fontaine Natlan Nod-Krai Snezhnaya Khaenri'ah]
+
+    add_column :boss_characters, :fight_region_location, :enum, enum_type: "fight_region_locations",  null: false
+
+    add_column :boss_characters, :fight_exact_location, :string
+  end
+end

--- a/db/migrate/20260730123748_remove_location_from_boss_character.rb
+++ b/db/migrate/20260730123748_remove_location_from_boss_character.rb
@@ -1,0 +1,5 @@
+class RemoveLocationFromBossCharacter < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :boss_characters, :location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_20_125249) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_123748) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "fight_region_locations", ["Liyue", "Montstadt", "Inazuma", "Sumeru", "Fontaine", "Natlan", "Nod-Krai", "Snezhnaya", "Khaenri'ah"]
   create_enum "regions", ["Liyue", "Fontaine", "Montstadt"]
 
   create_table "boss_characters", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "fight_exact_location"
+    t.enum "fight_region_location", null: false, enum_type: "fight_region_locations"
     t.boolean "is_weekly_boss", default: false
-    t.string "location"
     t.integer "recommended_level"
     t.datetime "updated_at", null: false
   end

--- a/test/fixtures/boss_characters.yml
+++ b/test/fixtures/boss_characters.yml
@@ -1,23 +1,27 @@
 stormterror_from_mondsatdt:
   id: 1016727071
   is_weekly_boss: true
-  location: Montstadt [Montagnes de Brillecouronne]
+  fight_region_location: Montstadt
+  fight_exact_location: Montagnes de Brillecouronne
   recommended_level: 18
 
 signora_from_mondsatdt:
   id: 1016727072
   is_weekly_boss: true
-  location: Inazuma [l'île Narukami - Tenshukaku]
+  fight_region_location: Inazuma
+  fight_exact_location: l'île Narukami «Tenshukaku»
   recommended_level: 30
 
 andrius_from_mondsatdt:
   id: 1016727073
   is_weekly_boss: true
-  location: Mondstadt [Territoire des Loups]
+  fight_region_location: Montstadt
+  fight_exact_location: Territoire des Loups
   recommended_level: 50
 
 tartaglia_from_mondsatdt:
   id: 1016727074
   is_weekly_boss: true
-  location: Liyue [Donjon «Chambre d'Or»]
+  fight_region_location: Liyue
+  fight_exact_location: Donjon «Chambre d'Or»
   recommended_level: 30

--- a/test/models/boss_character_test.rb
+++ b/test/models/boss_character_test.rb
@@ -2,22 +2,22 @@ require "test_helper"
 
 class BossCharacterTest < ActiveSupport::TestCase
   test "Should be able to create a boss character" do
-    boss_character = BossCharacter.create(is_weekly_boss: true, location: "Inazume - [Donjon «Ruines éparses»]", recommended_level: 30)
+    boss_character = BossCharacter.create(is_weekly_boss: true, fight_region_location: "Liyue", fight_exact_location: "Donjon «Ruines éparses»", recommended_level: 30)
     assert boss_character.valid?
   end
 
-  test "Should not be able to create a boss character if there isn't a location" do
-    boss_character = BossCharacter.create(is_weekly_boss: true, recommended_level: 30)
+  test "Should not be able to create a boss character if there isn't a region where you can fight the boss character" do
+    boss_character = BossCharacter.create(is_weekly_boss: true, fight_exact_location: "Donjon «Ruines éparses»", recommended_level: 30)
+    assert_not boss_character.valid?
+  end
+
+  test "Should not be able to create a boss character if there isn't a exact location to fight the boss character" do
+    boss_character = BossCharacter.create(is_weekly_boss: true, fight_region_location: "Liyue", recommended_level: 30)
     assert_not boss_character.valid?
   end
 
   test "Should not be able to create a boss character if there isn't a recommended level" do
-    boss_character = BossCharacter.create(is_weekly_boss: true, location: "Inazume - [Donjon «Ruines éparses»]")
-    assert_not boss_character.valid?
-  end
-
-  test "Should not be able to create a boss character if weekly_boss isn't set to ‘true’ or ‘false’" do
-    boss_character = BossCharacter.create(location: "Inazume - [Donjon «Ruines éparses»]", recommended_level: 30)
+    boss_character = BossCharacter.create(is_weekly_boss: true, fight_region_location: "Liyue", fight_exact_location: "Donjon «Ruines éparses»")
     assert_not boss_character.valid?
   end
 end


### PR DESCRIPTION
**Description:** 

- ajoute 2 nouvelles colonnes qui vont stocker la localisation exacte et la région,  où on trouve le personnage 'boss' pour pouvoir le combattre , et supprimer la colonne 'location'

-  On fait ces modifications pour pouvoir mieux contrôler le type de données qui sera dans chaque colonne, ce qu'on ne pouvait pas vraiment faire avec la colonne 'location' , car c'était toujours une chaîne de caractères et on pouvait pas vraiment s'assurer que les région écrite dans 'location' exister ou étais valide 