### PR TITLE
view all boss characters on the API 

### DIFF
--- a/app/controllers/api/v1/boss_characters_controller.rb
+++ b/app/controllers/api/v1/boss_characters_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::BossCharactersController < ApiController
   returns code: 200
 
   def index
-    boss_character = BossCharacter.all.map { |boss_character| BossCharacterJson.new(boss_character:).to_h }
-    render json: { boss_characters: boss_character }, status: 200
+    boss_characters = BossCharacter.all.map { |boss_character| BossCharacterJson.new(boss_character:).to_h }
+    render json: { boss_characters: boss_characters }, status: 200
   end
 end

--- a/app/controllers/api/v1/boss_characters_controller.rb
+++ b/app/controllers/api/v1/boss_characters_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::BossCharactersController < ApiController
+  resource_description  do
+    formats [ "json" ]
+  end
+
+  api :GET, "api/v1/boss_characters", "list all boss characters"
+  api_version "v1"
+  returns code: 200
+
+  def index
+    boss_character = BossCharacter.all.map { |boss_character| BossCharacterJson.new(boss_character:).to_h }
+    render json: { boss_characters: boss_character }, status: 200
+  end
+end

--- a/app/json/boss_character_json.rb
+++ b/app/json/boss_character_json.rb
@@ -6,7 +6,6 @@ class BossCharacterJson
   def to_h
     {
       id: @boss_character.id,
-      character_id: @boss_character.character.id,
       name: @boss_character.name,
       rarity: @boss_character.rarity,
       region: @boss_character.region,

--- a/app/json/boss_character_json.rb
+++ b/app/json/boss_character_json.rb
@@ -1,0 +1,20 @@
+class BossCharacterJson
+  def initialize(boss_character:)
+    @boss_character = boss_character
+  end
+
+  def to_h
+    {
+      id: @boss_character.id,
+      character_id: @boss_character.character.id,
+      name: @boss_character.name,
+      rarity: @boss_character.rarity,
+      region: @boss_character.region,
+      description: @boss_character.description,
+      fight_region_location: @boss_character.fight_region_location,
+      fight_exact_location: @boss_character.fight_exact_location,
+      is_weekly_boss: @boss_character.is_weekly_boss,
+      recommended_level: @boss_character.recommended_level
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :characters
       resources :playable_characters
+      resources :boss_characters
     end
   end
 end

--- a/test/controllers/api/v1/boss_characters_controller_test.rb
+++ b/test/controllers/api/v1/boss_characters_controller_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::BossCharacterControllerTest < ActionDispatch::IntegrationTest
+  test "Should get all boss characters" do
+    get api_v1_boss_characters_url
+
+    assert_response :success
+    assert_match(/json/, response.header["Content-Type"])
+
+    boss_character = boss_characters(:andrius_from_mondsatdt)
+    boss_character_to_json = BossCharacterJson.new(boss_character:).to_h
+
+    assert_includes response.parsed_body["boss_characters"], boss_character_to_json.as_json
+    assert_equal BossCharacter.count,  response.parsed_body["boss_characters"].count
+  end
+end

--- a/test/json/boss_character_json_test.rb
+++ b/test/json/boss_character_json_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class BossCharacterJsonTest  < ActiveSupport::TestCase
+  test "Should get a character json" do
+    boss_character = boss_characters(:andrius_from_mondsatdt)
+
+    expected_json = {
+      id: 1016727073,
+      character_id: 805628297,
+      name: "Andrius",
+      rarity: 0,
+      region: "Montstadt",
+      description: "Andrius, aussi connu sous le nom de “Loup du Nord” ou “Borée”, est un ancien dieu de Mondstadt et un boss hebdomadaire de Genshin Impact. Il protège le Royaume des Loups et veille avec bienveillance sur Razor. Il est le plus noble et le plus beau des âmes qui veillent sur le Lupical. Quand la meute est en péril, il émerge sous la forme d'un loup d'hydro et de cryo pour montrer ses crocs et ses griffes. Les humains ont rarement l'occasion de croiser le regard d'un loup, ainsi en a décidé le Loup du Nord.",
+      fight_region_location: "Montstadt",
+      fight_exact_location: "Territoire des Loups",
+      is_weekly_boss: true,
+      recommended_level: 50
+    }
+
+    boss_character_to_json = BossCharacterJson.new(boss_character:).to_h
+    assert_equal expected_json, boss_character_to_json
+  end
+end

--- a/test/json/boss_character_json_test.rb
+++ b/test/json/boss_character_json_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class BossCharacterJsonTest  < ActiveSupport::TestCase
-  test "Should get a character json" do
+  test "Should get a boss character serialized in JSON" do
     boss_character = boss_characters(:andrius_from_mondsatdt)
 
     expected_json = {

--- a/test/json/boss_character_json_test.rb
+++ b/test/json/boss_character_json_test.rb
@@ -6,7 +6,6 @@ class BossCharacterJsonTest  < ActiveSupport::TestCase
 
     expected_json = {
       id: 1016727073,
-      character_id: 805628297,
       name: "Andrius",
       rarity: 0,
       region: "Montstadt",


### PR DESCRIPTION
**Description:** 

- permet de voir tous les personnages de type 'boss' à 'http://localhost:3000/api/v1/boss_characters'


<img width="1614" height="962" alt="image" src="https://github.com/user-attachments/assets/7bbb993b-9469-4550-b38e-4b635bdd28bc" />
