### PR TITLE
view the details of a boss character on the api

### DIFF
--- a/app/controllers/api/v1/boss_characters_controller.rb
+++ b/app/controllers/api/v1/boss_characters_controller.rb
@@ -3,6 +3,8 @@ class Api::V1::BossCharactersController < ApiController
     formats [ "json" ]
   end
 
+  before_action :find_boss_character, only: [ :show ]
+
   api :GET, "api/v1/boss_characters", "list all boss characters"
   api_version "v1"
   returns code: 200
@@ -10,5 +12,20 @@ class Api::V1::BossCharactersController < ApiController
   def index
     boss_characters = BossCharacter.all.map { |boss_character| BossCharacterJson.new(boss_character:).to_h }
     render json: { boss_characters: boss_characters }, status: 200
+  end
+
+  api :GET, "api/v1/boss_characters/:id", "show an boss character"
+  api_version "v1"
+  returns code: 200
+  error :not_found, I18n.t("boss_characters.active_record_error.record_not_found")
+
+  def show
+    render json: BossCharacterJson.new(boss_character: @boss_character).to_h, status: 200
+  end
+
+  def find_boss_character
+    @boss_character = BossCharacter.find(params[:id])
+  rescue ActiveRecord::RecordNotFound => e
+    render status: :not_found, json: { error: I18n.t("boss_characters.active_record_error.record_not_found"), details: { field: [ e ] } }
   end
 end

--- a/test/controllers/api/v1/boss_characters_controller_test.rb
+++ b/test/controllers/api/v1/boss_characters_controller_test.rb
@@ -15,4 +15,26 @@ class Api::V1::BossCharacterControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.parsed_body["boss_characters"], boss_character_to_json.as_json
     assert_equal BossCharacter.count,  response.parsed_body["boss_characters"].count
   end
+
+  test "Should render a boss character if we can find the boss character's ID" do
+    boss_character = boss_characters(:andrius_from_mondsatdt)
+
+    get api_v1_boss_character_url(id: boss_character.id)
+
+    assert_response :success
+
+    expected_response = BossCharacterJson.new(boss_character:).to_h
+
+    assert_equal expected_response.as_json, response.parsed_body
+  end
+
+  test "Should render an error message if we cannot find the boss character's ID" do
+    get api_v1_boss_character_url(id: 0)
+
+    assert_response :not_found
+
+    expected_error_message = I18n.t("boss_characters.active_record_error.record_not_found")
+
+    assert_equal expected_error_message.as_json, response.parsed_body[:error]
+  end
 end


### PR DESCRIPTION
**Description:** 

- permet de voir les détails d'un personnage de type 'boss', à cet endpoint  http://localhost:3000/api/v1/boss_characters/:id 

**Les differents cas :** 

1/ On trouve l'ID du boss , et on a les différentes informations sur le personnage 'boss' : 

<img width="1621" height="405" alt="image" src="https://github.com/user-attachments/assets/273266a6-8c63-4f3a-87a4-b663d6ae72da" />

2/  On ne trouve pas l'ID du boss , et on aura un message d'erreur 

<img width="1625" height="420" alt="image" src="https://github.com/user-attachments/assets/11d7daef-9b17-40b2-bcd5-ca83111403df" />
