### PR TITLE
add the action 'create' to be able to add new character

### DIFF
--- a/app/controllers/api/v1/boss_characters_controller.rb
+++ b/app/controllers/api/v1/boss_characters_controller.rb
@@ -23,9 +23,32 @@ class Api::V1::BossCharactersController < ApiController
     render json: BossCharacterJson.new(boss_character: @boss_character).to_h, status: 200
   end
 
+  api :POST, "api/v1/boss_characters", "create boss character"
+  api_version "v1"
+  returns code: 200
+  error :unprocessable_entity, "can't create a boss character who doesn't follow the model's validation"
+
+  def create
+    ActiveRecord::Base.transaction do
+      @boss_character = BossCharacter.create!(boss_character_params)
+      @character = Character.create!(character_params.merge(characterable: @boss_character))
+    end
+    render json: BossCharacterJson.new(boss_character: @boss_character).to_h, status: :created
+  rescue ActiveRecord::RecordInvalid => e
+    render status: :unprocessable_entity, json: { error: I18n.t("boss_characters.new.record_invalid"), details: { field: [ e.message ] } }
+  end
+
   def find_boss_character
     @boss_character = BossCharacter.find(params[:id])
   rescue ActiveRecord::RecordNotFound => e
     render status: :not_found, json: { error: I18n.t("boss_characters.active_record_error.record_not_found"), details: { field: [ e ] } }
+  end
+
+  def boss_character_params
+    params.permit(:is_weekly_boss, :recommended_level, :fight_region_location, :fight_exact_location)
+  end
+
+  def character_params
+    params.permit(:name, :description, :rarity, :region)
   end
 end

--- a/test/controllers/api/v1/boss_characters_controller_test.rb
+++ b/test/controllers/api/v1/boss_characters_controller_test.rb
@@ -37,4 +37,68 @@ class Api::V1::BossCharacterControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal expected_error_message.as_json, response.parsed_body[:error]
   end
+
+  test "Should be able to create a new boss character" do
+    assert_difference [ -> { BossCharacter.count }, -> { Character.count } ], +1  do
+      post api_v1_boss_characters_url, params: {
+          name: "lll",
+          region: "Montstadt",
+          rarity: 3,
+          description: "Rosalyne-Kruzchka Lohefalter, également appelée Signora, était la Huitième Exécutrice des Fatui.",
+          is_weekly_boss: true,
+          recommended_level: 32,
+          fight_region_location: "Liyue",
+          fight_exact_location: "l'île Narukami «Tenshukaku»"
+      }
+    end
+    assert_response :success
+
+    boss_character = BossCharacter.last
+    boss_character_to_json =  BossCharacterJson.new(boss_character:).to_h
+    assert_equal response.parsed_body, boss_character_to_json.as_json
+  end
+
+  test "Should not be able to create a boss character if a character's field validation failed" do
+    assert_difference -> { Character.count } => 0, -> { BossCharacter.count } => 0 do
+      post api_v1_boss_characters_url, params: {
+        name: "",
+        region: "Montstadt",
+        rarity: 3,
+        description: "Rosalyne-Kruzchka Lohefalter, également appelée Signora, était la Huitième Exécutrice des Fatui.",
+        is_weekly_boss: true,
+        recommended_level: 32,
+        fight_region_location: "Liyue",
+        fight_exact_location: "l'île test"
+      }
+    end
+    assert_response :unprocessable_entity
+
+    expected_error_message = { error: I18n.t("boss_characters.new.record_invalid"), details: { field: [ "Validation failed: Name can't be blank" ] } }
+    assert_equal response.parsed_body,  expected_error_message.as_json
+
+    assert_not_equal BossCharacter.last.fight_exact_location, "l'île test"
+    assert_not_equal BossCharacter.last.name, ""
+  end
+
+  test "Should not be able to create a boss character if validation of a boss character's field failed" do
+    assert_difference -> { Character.count } => 0, -> { BossCharacter.count } => 0 do
+      post api_v1_boss_characters_url, params: {
+        name: "test_02",
+        region: "Montstadt",
+        rarity: 3,
+        description: "Rosalyne-Kruzchka Lohefalter, également appelée Signora, était la Huitième Exécutrice des Fatui.",
+        is_weekly_boss: false,
+        recommended_level: 30,
+        fight_region_location: "Liyue",
+        fight_exact_location: "l'île !!"
+      }
+    end
+    assert_response :unprocessable_entity
+
+    expected_error_message = { error: I18n.t("boss_characters.new.record_invalid"), details: { field: [ "Validation failed: Fight exact location is invalid" ] } }
+    assert_equal response.parsed_body,  expected_error_message.as_json
+
+    assert_not_equal BossCharacter.last.fight_exact_location, "l'île !!"
+    assert_not_equal BossCharacter.last.name, "test_02"
+  end
 end


### PR DESCRIPTION
**Description:** 

- Permet de créer un personnage de type 'boss' (boss_character) sur l'API

Les differents cas : 

1/ On entre des valeur valide et l'object est créer 

<img width="1025" height="640" alt="image" src="https://github.com/user-attachments/assets/6b80fe77-9a38-4b83-82b8-dee26650abff" />

2/ On entre des valeur invalid d'après le modele, et on aura un message d'erreur comme réponse 

<img width="1025" height="599" alt="image" src="https://github.com/user-attachments/assets/17a95eae-b35f-4c31-9ded-127e4629644c" />
